### PR TITLE
Use levenshtein score to approximate moves.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,10 +3,12 @@ module github.com/chainguard-dev/bincapz
 go 1.21.6
 
 require (
+	github.com/agext/levenshtein v1.2.3
 	github.com/google/go-cmp v0.6.0
 	github.com/hillu/go-yara/v4 v4.3.2
 	github.com/liamg/magic v0.0.1
 	github.com/olekukonko/tablewriter v0.0.5
+	golang.org/x/term v0.18.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/klog/v2 v2.120.1
 )
@@ -15,5 +17,4 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	golang.org/x/sys v0.18.0 // indirect
-	golang.org/x/term v0.18.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
+github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=

--- a/pkg/bincapz/bincapz.go
+++ b/pkg/bincapz/bincapz.go
@@ -28,8 +28,12 @@ type FileReport struct {
 	Behaviors         map[string]Behavior `json:",omitempty" yaml:",omitempty"`
 	FilteredBehaviors int                 `json:",omitempty" yaml:",omitempty"`
 
-	PreviousRiskScore int    `json:",omitempty" yaml:",omitempty"`
-	PreviousRiskLevel string `json:",omitempty" yaml:",omitempty"`
+	// The relative path we think this moved from.
+	PreviousRelPath string `json:",omitempty" yaml:",omitempty"`
+	// The levenshtein distance between the previous path and the current path
+	PreviousRelPathScore float64 `json:",omitempty" yaml:",omitempty"`
+	PreviousRiskScore    int     `json:",omitempty" yaml:",omitempty"`
+	PreviousRiskLevel    string  `json:",omitempty" yaml:",omitempty"`
 
 	RiskScore int
 	RiskLevel string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -35,9 +35,14 @@ func (r Markdown) Full(rep bincapz.Report) error {
 		markdownTable(&fr, r.w, tableConfig{Title: fmt.Sprintf("## Added: %s\n\nOverall risk: %s", f, decorativeRisk(fr.RiskScore, fr.RiskLevel)), DiffAdded: true})
 	}
 
-	for _, fr := range rep.Diff.Modified {
+	for f, fr := range rep.Diff.Modified {
 		fr := fr
-		title := fmt.Sprintf("## Changed: %s\n", fr.Path)
+		var title string
+		if fr.PreviousRelPath != "" {
+			title = fmt.Sprintf("## Moved: %s -> %s (score: %f)", fr.PreviousRelPath, f, fr.PreviousRelPathScore)
+		} else {
+			title = fmt.Sprintf("## Changed: %s\n", f)
+		}
 		if fr.RiskScore != fr.PreviousRiskScore {
 			title = fmt.Sprintf("%s\nPrevious Risk: %s\nNew Risk:      %s",
 				title,
@@ -68,6 +73,9 @@ func markdownTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) {
 	}
 
 	if len(kbs) == 0 {
+		if fr.PreviousRelPath != "" && rc.Title != "" {
+			fmt.Fprintf(w, "%s\n\n", rc.Title)
+		}
 		return
 	}
 

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -58,8 +58,12 @@ func (r Simple) Full(rep bincapz.Report) error {
 		}
 	}
 
-	for _, fr := range rep.Diff.Modified {
-		fmt.Fprintf(r.w, "*** changed: %s\n", fr.Path)
+	for f, fr := range rep.Diff.Modified {
+		if fr.PreviousRelPath != "" {
+			fmt.Fprintf(r.w, ">>> moved: %s -> %s (score: %f)\n", fr.PreviousRelPath, f, fr.PreviousRelPathScore)
+		} else {
+			fmt.Fprintf(r.w, "*** changed: %s\n", fr.Path)
+		}
 		bs := []string{}
 		for k := range fr.Behaviors {
 			bs = append(bs, k)

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -114,9 +114,14 @@ func (r Terminal) Full(rep bincapz.Report) error {
 		})
 	}
 
-	for _, fr := range rep.Diff.Modified {
+	for f, fr := range rep.Diff.Modified {
 		fr := fr
-		title := fmt.Sprintf("Changed: %s", fr.Path)
+		var title string
+		if fr.PreviousRelPath != "" {
+			title = fmt.Sprintf("Moved: %s -> %s (score: %f)", fr.PreviousRelPath, f, fr.PreviousRelPathScore)
+		} else {
+			title = fmt.Sprintf("Changed: %s", f)
+		}
 		if fr.RiskScore != fr.PreviousRiskScore {
 			title = fmt.Sprintf("%s\nPrevious Risk: %s\nNew Risk:      %s",
 				title,
@@ -150,6 +155,9 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) {
 	}
 
 	if len(kbs) == 0 {
+		if fr.PreviousRelPath != "" && title != "" {
+			fmt.Fprintf(w, "%s\n", title)
+		}
 		return
 	}
 


### PR DESCRIPTION
One of the most common sources of diffs we are seeing comparing the filesystems of APKs is when there is an ABI change, but not an actual capability change.  This shows up as a potentially noisy Deleted / Added with the full capability listing.

This change adds a post-pass to the reporting computation that walks the Added/Deleted file lists, and if two paths are a >90% match, then we treat them as a "move" and combine their reports in a similar fashion to modifications.

This also incorporates the notion of moves into the report and adjusts some of the rendering to surface these as moves with the similarity score (so we can tune this).