### PR TITLE
terminal output: revert reverse risk sorting

### DIFF
--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -157,7 +157,7 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) {
 		if kbs[i].Behavior.RiskScore == kbs[j].Behavior.RiskScore {
 			return kbs[i].Key < kbs[j].Key
 		}
-		return kbs[i].Behavior.RiskScore > kbs[j].Behavior.RiskScore
+		return kbs[i].Behavior.RiskScore < kbs[j].Behavior.RiskScore
 	})
 
 	data := [][]string{}


### PR DESCRIPTION
It turns out that I prefer the output this way when the output doesn't fit within a terminal window.