### PR TITLE
Fix the top level tests, fix a typo in the name.

### DIFF
--- a/bincapz_test.go
+++ b/bincapz_test.go
@@ -85,7 +85,7 @@ func TestSimple(t *testing.T) {
 
 	fs.WalkDir(fileSystem, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			log.Fatal(err)
+			t.Fatal(err)
 		}
 		if !strings.HasSuffix(path, ".simple") {
 			return nil

--- a/testdata/Python/valyrian_debug_setup.py
+++ b/testdata/Python/valyrian_debug_setup.py
@@ -1,4 +1,4 @@
-# based on valryian_debug-0.0.1 from the backstabbers knife collection
+# based on valyrian_debug-0.0.1 from the backstabbers knife collection
 import json
 import os
 import sys

--- a/testdata/Python/valyrian_debug_setup.py.simple
+++ b/testdata/Python/valyrian_debug_setup.py.simple
@@ -1,4 +1,5 @@
-# testdata/Python/valryian_debug_setup.py
+# testdata/Python/valyrian_debug_setup.py
+combo/backdoor/py_setuptools
 combo/recon/system_network
 exec/pipe
 exec/program

--- a/testdata/macOS/libffmpeg.dirty.mdiff
+++ b/testdata/macOS/libffmpeg.dirty.mdiff
@@ -1,4 +1,4 @@
-## Changed: testdata/macOS/libffmpeg.dirty.dylib
+## Changed: .
 
 Previous Risk: ✅ 2/MEDIUM
 New Risk:      🚨 4/CRITICAL


### PR DESCRIPTION
Fixes #96 

Also the names of the tests were wrong so fixed those so it's easier to find where they came from.

I think the test was wrong, because I see the combo/backdoor/py_setuptools when I run this:

```
➜  bincapz git:(fix-tests) ✗ go run . third_party/yara-rules-full.yar testdata/Python/valyrian_debug_setup.py | grep combo/backdoor
3/HIGH  combo/backdoor/py_setuptools  python library installer that executes external commands: "os.system( setup( setuptools"
```

And the other one seems like it does indeed just print `.` instead of the full path:

```
➜  bincapz git:(fix-tests) ✗ go run . -diff testdata/macOS/libffmpeg.dirty.dylib testdata/macOS/libffmpeg.dylib
Changed: .
Previous Risk: 🚨 4/CRITICAL
New Risk:      ✅ 2/MEDIUM
```