### PR TITLE
Move to clog, plumb context through as necessary.

### DIFF
--- a/bincapz_test.go
+++ b/bincapz_test.go
@@ -191,7 +191,6 @@ func TestDiff(t *testing.T) {
 			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
 			ctx := clog.WithLogger(context.Background(), logger)
 			res, err := action.Diff(ctx, bc)
-
 			if err != nil {
 				t.Fatalf("diff failed: %v", err)
 			}

--- a/bincapz_test.go
+++ b/bincapz_test.go
@@ -5,8 +5,10 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -16,13 +18,18 @@ import (
 	"github.com/chainguard-dev/bincapz/pkg/bincapz"
 	"github.com/chainguard-dev/bincapz/pkg/render"
 	"github.com/chainguard-dev/bincapz/pkg/rules"
+	"github.com/chainguard-dev/clog"
+	"github.com/chainguard-dev/clog/slogtest"
 	"github.com/google/go-cmp/cmp"
 )
 
 var testDataRoot = "testdata"
 
 func TestJSON(t *testing.T) {
-	yrs, err := rules.Compile(ruleFs, false)
+	ctx := slogtest.TestContextWithLogger(t)
+	clog.FromContext(ctx).With("test", "TestJSON")
+
+	yrs, err := rules.Compile(ctx, ruleFs, false)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -64,7 +71,9 @@ func TestJSON(t *testing.T) {
 				Rules:      yrs,
 			}
 
-			got, err := action.Scan(bc)
+			tcLogger := clog.FromContext(ctx).With("test", name)
+			ctx := clog.WithLogger(ctx, tcLogger)
+			got, err := action.Scan(ctx, bc)
 			if err != nil {
 				t.Fatalf("scan failed: %v", err)
 			}
@@ -78,7 +87,10 @@ func TestJSON(t *testing.T) {
 }
 
 func TestSimple(t *testing.T) {
-	yrs, err := rules.Compile(ruleFs, false)
+	ctx := slogtest.TestContextWithLogger(t)
+	clog.FromContext(ctx).With("test", "simple")
+
+	yrs, err := rules.Compile(ctx, ruleFs, false)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -117,12 +129,14 @@ func TestSimple(t *testing.T) {
 				Rules:      yrs,
 			}
 
-			res, err := action.Scan(bc)
+			tcLogger := clog.FromContext(ctx).With("test", name)
+			ctx := clog.WithLogger(ctx, tcLogger)
+			res, err := action.Scan(ctx, bc)
 			if err != nil {
 				t.Fatalf("scan failed: %v", err)
 			}
 
-			if err := simple.Full(*res); err != nil {
+			if err := simple.Full(ctx, *res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 
@@ -136,7 +150,7 @@ func TestSimple(t *testing.T) {
 }
 
 func TestDiff(t *testing.T) {
-	yrs, err := rules.Compile(ruleFs, true)
+	yrs, err := rules.Compile(context.TODO(), ruleFs, true)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -174,12 +188,15 @@ func TestDiff(t *testing.T) {
 				Rules:      yrs,
 			}
 
-			res, err := action.Diff(bc)
+			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
+			ctx := clog.WithLogger(context.Background(), logger)
+			res, err := action.Diff(ctx, bc)
+
 			if err != nil {
 				t.Fatalf("diff failed: %v", err)
 			}
 
-			if err := simple.Full(*res); err != nil {
+			if err := simple.Full(ctx, *res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 
@@ -192,7 +209,9 @@ func TestDiff(t *testing.T) {
 }
 
 func TestMarkdown(t *testing.T) {
-	yrs, err := rules.Compile(ruleFs, false)
+	ctx := slogtest.TestContextWithLogger(t)
+	clog.FromContext(ctx).With("test", "TestMarkDown")
+	yrs, err := rules.Compile(ctx, ruleFs, false)
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -231,12 +250,15 @@ func TestMarkdown(t *testing.T) {
 				Rules:      yrs,
 			}
 
-			res, err := action.Scan(bc)
+			tcLogger := clog.FromContext(ctx).With("test", name)
+			ctx := clog.WithLogger(ctx, tcLogger)
+
+			res, err := action.Scan(ctx, bc)
 			if err != nil {
 				t.Fatalf("scan failed: %v", err)
 			}
 
-			if err := simple.Full(*res); err != nil {
+			if err := simple.Full(ctx, *res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -4,17 +4,16 @@ go 1.21.6
 
 require (
 	github.com/agext/levenshtein v1.2.3
+	github.com/chainguard-dev/clog v1.3.1
 	github.com/google/go-cmp v0.6.0
 	github.com/hillu/go-yara/v4 v4.3.2
 	github.com/liamg/magic v0.0.1
 	github.com/olekukonko/tablewriter v0.0.5
 	golang.org/x/term v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
-	k8s.io/klog/v2 v2.120.1
 )
 
 require (
-	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	golang.org/x/sys v0.19.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/agext/levenshtein v1.2.3 h1:YB2fHEn0UJagG8T1rrWknE3ZQzWM06O8AMAatNn7lmo=
 github.com/agext/levenshtein v1.2.3/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/chainguard-dev/clog v1.3.1 h1:CDNCty5WKQhJzoOPubk0GdXt+bPQyargmfClqebrpaQ=
+github.com/chainguard-dev/clog v1.3.1/go.mod h1:cV516KZWqYc/phZsCNwF36u/KMGS+Gj5Uqeb8Hlp95Y=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
-github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/hillu/go-yara/v4 v4.3.2 h1:HGqUN3ORUduWZbb95RQjut4UzavGDbtt/C6SnGB3Amk=
@@ -30,5 +30,3 @@ gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible h1:VsBPFP1AI068pPrMxtb/S8Zkgf9xEmTLJjfM+P5UIEo=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=
-k8s.io/klog/v2 v2.120.1 h1:QXU6cPEOIslTGvZaXvFWiP9VKyeet3sawzTOvdXb4Vw=
-k8s.io/klog/v2 v2.120.1/go.mod h1:3Jpz1GvMt720eyJH1ckRHK1EDfpxISzJ7I9OYgaDtPE=

--- a/pkg/action/programkind_test.go
+++ b/pkg/action/programkind_test.go
@@ -6,6 +6,8 @@ package action
 import (
 	"fmt"
 	"testing"
+
+	"github.com/chainguard-dev/clog/slogtest"
 )
 
 func TestProgramKindMagic(_ *testing.T) {
@@ -36,7 +38,8 @@ func TestProgramStringMatch(t *testing.T) {
 	}}
 	for _, tt := range tests {
 		t.Run(tt.filename, func(t *testing.T) {
-			got := programKind(fmt.Sprintf("testdata/%s", tt.filename))
+			ctx := slogtest.TestContextWithLogger(t)
+			got := programKind(ctx, fmt.Sprintf("testdata/%s", tt.filename))
 			if got != tt.want {
 				t.Errorf("programKind() = %v, want %v", got, tt.want)
 			}

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -4,26 +4,28 @@
 package action
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/chainguard-dev/bincapz/pkg/bincapz"
 	"github.com/chainguard-dev/bincapz/pkg/report"
+	"github.com/chainguard-dev/clog"
 	"github.com/hillu/go-yara/v4"
-	"k8s.io/klog/v2"
 )
 
 // return a list of files within a path.
-func findFilesRecursively(root string) ([]string, error) {
-	klog.V(1).Infof("finding files in %s ...", root)
+func findFilesRecursively(ctx context.Context, root string) ([]string, error) {
+	clog.FromContext(ctx).Infof("finding files in %s ...", root)
 	files := []string{}
 
 	err := filepath.Walk(root,
 		func(path string, info os.FileInfo, err error) error {
 			if err != nil {
-				klog.Errorf("walk %s: %v", path, err)
+				clog.FromContext(ctx).Errorf("walk %s: %v", path, err)
 				return err
 			}
 			if info.IsDir() {
@@ -39,22 +41,24 @@ func findFilesRecursively(root string) ([]string, error) {
 	return files, err
 }
 
-func scanSinglePath(c Config, yrs *yara.Rules, path string) (*bincapz.FileReport, error) {
+func scanSinglePath(ctx context.Context, c Config, yrs *yara.Rules, path string) (*bincapz.FileReport, error) {
+	logger := clog.FromContext(ctx)
 	var mrs yara.MatchRules
-	klog.V(1).Infof("scanning: %s", path)
-	kind := programKind(path)
-	klog.V(1).Infof("%s kind: %q", path, kind)
+	logger = logger.With("path", path)
+	kind := programKind(ctx, path)
+	logger = logger.With("kind", kind)
+	logger.Info("scanning")
 	if !c.IncludeDataFiles && kind == "" {
-		klog.Infof("not a program: %s", path)
+		logger.Info("not a program")
 		return &bincapz.FileReport{Skipped: "data file"}, nil
 	}
 
 	if err := yrs.ScanFile(path, 0, 0, &mrs); err != nil {
-		klog.Infof("skipping %s - %v", path, err)
+		logger.Info("skipping", slog.Any("error", err))
 		return &bincapz.FileReport{Path: path, Error: fmt.Sprintf("scanfile: %v", err)}, nil
 	}
 
-	fr, err := report.Generate(path, mrs, c.IgnoreTags, c.MinLevel)
+	fr, err := report.Generate(ctx, path, mrs, c.IgnoreTags, c.MinLevel)
 	if err != nil {
 		return nil, err
 	}
@@ -65,8 +69,9 @@ func scanSinglePath(c Config, yrs *yara.Rules, path string) (*bincapz.FileReport
 	return &fr, nil
 }
 
-func Scan(c Config) (*bincapz.Report, error) {
-	//	klog.Infof("scan config: %+v", c)
+func Scan(ctx context.Context, c Config) (*bincapz.Report, error) {
+	logger := clog.FromContext(ctx)
+	logger.Debug("scan", slog.Any("config", c))
 	r := &bincapz.Report{
 		Files: map[string]bincapz.FileReport{},
 	}
@@ -79,25 +84,25 @@ func Scan(c Config) (*bincapz.Report, error) {
 	}
 
 	yrs := c.Rules
-	klog.Infof("%d rules loaded", len(yrs.GetRules()))
+	logger.Infof("%d rules loaded", len(yrs.GetRules()))
 
 	for _, sp := range c.ScanPaths {
-		rp, err := findFilesRecursively(sp)
+		rp, err := findFilesRecursively(ctx, sp)
 		if err != nil {
 			return nil, fmt.Errorf("find files: %w", err)
 		}
 		// TODO: support zip files and such
 		for _, p := range rp {
-			fr, err := scanSinglePath(c, yrs, p)
+			fr, err := scanSinglePath(ctx, c, yrs, p)
 			if err != nil {
-				klog.Errorf("scan path: %v", err)
+				logger.Errorf("scan path: %v", err)
 				continue
 			}
 			if fr == nil {
 				continue
 			}
 			if c.Renderer != nil {
-				if err := c.Renderer.File(*fr); err != nil {
+				if err := c.Renderer.File(ctx, *fr); err != nil {
 					return r, fmt.Errorf("render: %w", err)
 				}
 			}

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -19,11 +20,11 @@ func NewJSON(w io.Writer) JSON {
 	return JSON{w: w}
 }
 
-func (r JSON) File(_ bincapz.FileReport) error {
+func (r JSON) File(_ context.Context, _ bincapz.FileReport) error {
 	return nil
 }
 
-func (r JSON) Full(rep bincapz.Report) error {
+func (r JSON) Full(_ context.Context, rep bincapz.Report) error {
 	j, err := json.MarshalIndent(rep, "", "    ")
 	if err != nil {
 		return err

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -12,8 +13,8 @@ import (
 
 // Renderer is a common interface for Renderers.
 type Renderer interface {
-	File(bincapz.FileReport) error
-	Full(bincapz.Report) error
+	File(context.Context, bincapz.FileReport) error
+	Full(context.Context, bincapz.Report) error
 }
 
 // New returns a new Renderer.

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"sort"
@@ -19,7 +20,7 @@ func NewSimple(w io.Writer) Simple {
 	return Simple{w: w}
 }
 
-func (r Simple) File(fr bincapz.FileReport) error {
+func (r Simple) File(_ context.Context, fr bincapz.FileReport) error {
 	fmt.Fprintf(r.w, "# %s\n", fr.Path)
 	bs := []string{}
 
@@ -33,7 +34,7 @@ func (r Simple) File(fr bincapz.FileReport) error {
 	return nil
 }
 
-func (r Simple) Full(rep bincapz.Report) error {
+func (r Simple) Full(_ context.Context, rep bincapz.Report) error {
 	for f, fr := range rep.Diff.Removed {
 		fmt.Fprintf(r.w, "--- missing: %s\n", f)
 

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -35,7 +35,7 @@ type tableConfig struct {
 	DiffAdded   bool
 }
 
-func forceWrap(ctx context.Context, s string, x int) string {
+func forceWrap(_ context.Context, s string, x int) string {
 	words, _ := tablewriter.WrapString(s, x)
 	fw := []string{}
 	for _, w := range words {

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -4,16 +4,18 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"sort"
 	"strings"
 
 	"github.com/chainguard-dev/bincapz/pkg/bincapz"
+	"github.com/chainguard-dev/clog"
 	"github.com/olekukonko/tablewriter"
 	"golang.org/x/term"
-	"k8s.io/klog/v2"
 )
 
 // ignoreMeta are fields to ignore in output.
@@ -33,12 +35,12 @@ type tableConfig struct {
 	DiffAdded   bool
 }
 
-func forceWrap(s string, x int) string {
+func forceWrap(ctx context.Context, s string, x int) string {
 	words, _ := tablewriter.WrapString(s, x)
 	fw := []string{}
 	for _, w := range words {
 		if len(w) > x-2 {
-			klog.Infof("wrapping %s - longer than %d", w, x-2)
+			clog.Info("wrapping", slog.Any("word", w), slog.Int("length", len(w)), slog.Int("max", x-2))
 			w = w[0:x-2] + ".."
 		}
 		fw = append(fw, w)
@@ -46,14 +48,14 @@ func forceWrap(s string, x int) string {
 	return strings.Join(fw, "\n")
 }
 
-func terminalWidth() int {
+func terminalWidth(ctx context.Context) int {
 	if !term.IsTerminal(0) {
 		return 120
 	}
 
 	width, _, err := term.GetSize(0)
 	if err != nil {
-		klog.Errorf("term.getsize: %v", err)
+		clog.ErrorContext(ctx, "term.getsize", slog.Any("error", err))
 		return 80
 	}
 
@@ -91,8 +93,8 @@ func shortRisk(s string) string {
 	return short
 }
 
-func (r Terminal) File(fr bincapz.FileReport) error {
-	renderTable(&fr, r.w,
+func (r Terminal) File(ctx context.Context, fr bincapz.FileReport) error {
+	renderTable(ctx, &fr, r.w,
 		tableConfig{
 			Title: fmt.Sprintf("Path: %s\nRisk: %s", fr.Path, decorativeRisk(fr.RiskScore, fr.RiskLevel)),
 		},
@@ -100,10 +102,10 @@ func (r Terminal) File(fr bincapz.FileReport) error {
 	return nil
 }
 
-func (r Terminal) Full(rep bincapz.Report) error {
+func (r Terminal) Full(ctx context.Context, rep bincapz.Report) error {
 	for f, fr := range rep.Diff.Removed {
 		fr := fr
-		renderTable(&fr, r.w, tableConfig{
+		renderTable(ctx, &fr, r.w, tableConfig{
 			Title:       fmt.Sprintf("➖ Deleted: %s", f),
 			DiffRemoved: true,
 		})
@@ -111,7 +113,7 @@ func (r Terminal) Full(rep bincapz.Report) error {
 
 	for f, fr := range rep.Diff.Added {
 		fr := fr
-		renderTable(&fr, r.w, tableConfig{
+		renderTable(ctx, &fr, r.w, tableConfig{
 			Title:     fmt.Sprintf("Added: %s\nAdded Risk: %s", f, decorativeRisk(fr.RiskScore, fr.RiskLevel)),
 			DiffAdded: true,
 		})
@@ -131,14 +133,14 @@ func (r Terminal) Full(rep bincapz.Report) error {
 				decorativeRisk(fr.PreviousRiskScore, fr.PreviousRiskLevel),
 				decorativeRisk(fr.RiskScore, fr.RiskLevel))
 		}
-		renderTable(&fr, r.w, tableConfig{
+		renderTable(ctx, &fr, r.w, tableConfig{
 			Title: title,
 		})
 	}
 	return nil
 }
 
-func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint: cyclop // TODO: review this cyclomatic complexity for function renderTable is 39, max is 37
+func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint: cyclop // TODO: review this cyclomatic complexity for function renderTable is 39, max is 37
 	title := rc.Title
 
 	path := fr.Path
@@ -179,14 +181,14 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint
 		}
 	}
 
-	tWidth := terminalWidth()
+	tWidth := terminalWidth(ctx)
 	keyWidth := 36
 	riskWidth := 7
 	padding := 6
 	maxKeyLen := 0
 
 	for _, k := range kbs {
-		key := forceWrap(k.Key, keyWidth)
+		key := forceWrap(ctx, k.Key, keyWidth)
 		if len(key) > maxKeyLen {
 			maxKeyLen = len(key)
 		}
@@ -197,7 +199,7 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint
 		descWidth = 120
 	}
 
-	klog.Infof("terminal width: %d - desc width: %d", tWidth, descWidth)
+	clog.InfoContext(ctx, "terminal width", slog.Int("width", tWidth), slog.Int("descWidth", descWidth))
 
 	for _, k := range kbs {
 		desc := k.Behavior.Description
@@ -213,13 +215,11 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint
 			}
 		}
 
-		key := forceWrap(k.Key, keyWidth)
+		key := forceWrap(ctx, k.Key, keyWidth)
 		words, _ := tablewriter.WrapString(desc, descWidth)
-
-		//		klog.Infof("%s / %s - %s", k.Key, desc, k.Behavior.)
 		desc = strings.Join(words, "\n")
 		if len(k.Behavior.Values) > 0 {
-			klog.Infof("VALUES: %s", k.Behavior.Values)
+			clog.InfoContext(ctx, "Values", slog.String("description", k.Behavior.Description), slog.Any("values", k.Behavior.Values))
 			values := strings.Join(k.Behavior.Values, "\n")
 			before := " \""
 			after := "\""
@@ -227,7 +227,7 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint
 				before = "\n"
 				after = ""
 			}
-			desc = fmt.Sprintf("%s:%s%s%s", desc, before, forceWrap(strings.Join(k.Behavior.Values, "\n"), descWidth), after)
+			desc = fmt.Sprintf("%s:%s%s%s", desc, before, forceWrap(ctx, strings.Join(k.Behavior.Values, "\n"), descWidth), after)
 		}
 
 		// lowercase first character for consistency
@@ -265,7 +265,7 @@ func renderTable(fr *bincapz.FileReport, w io.Writer, rc tableConfig) { //nolint
 	}
 
 	tableWidth := maxKeyLen + maxDescWidth + padding + maxRiskWidth
-	klog.Infof("table width: %d", tableWidth)
+	clog.InfoContextf(ctx, "table width: %d", tableWidth)
 	fmt.Fprintf(w, "%s\n", strings.Repeat("-", tableWidth))
 	table.SetNoWhiteSpace(true)
 	table.SetTablePadding("  ")

--- a/pkg/render/yaml.go
+++ b/pkg/render/yaml.go
@@ -4,6 +4,7 @@
 package render
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -19,11 +20,11 @@ func NewYAML(w io.Writer) YAML {
 	return YAML{w: w}
 }
 
-func (r YAML) File(_ bincapz.FileReport) error {
+func (r YAML) File(_ context.Context, _ bincapz.FileReport) error {
 	return nil
 }
 
-func (r YAML) Full(rep bincapz.Report) error {
+func (r YAML) Full(_ context.Context, rep bincapz.Report) error {
 	yaml, err := yaml.Marshal(rep)
 	if err != nil {
 		return err

--- a/testdata/does-nothing/does-nothing.go
+++ b/testdata/does-nothing/does-nothing.go
@@ -3,8 +3,8 @@
 
 package main
 
-import "k8s.io/klog/v2"
+import "fmt"
 
 func main() {
-	klog.Infof("You see, we don't do much")
+	fmt.Printf("You see, we don't do much")
 }


### PR DESCRIPTION
Move to use structured logging that we use elsewhere, then plumb context through as necessary.

Add -log-source (bool) flag that will give details on the source files for the logs, off by default since noisy and more expensive.