### PR TITLE
Reduce noisy logging messages

### DIFF
--- a/pkg/action/diff.go
+++ b/pkg/action/diff.go
@@ -15,7 +15,6 @@ import (
 )
 
 func relFileReport(ctx context.Context, c Config, path string) (map[string]bincapz.FileReport, error) {
-	logger := clog.FromContext(ctx).With("path", path)
 	fromPath := path
 	fromConfig := c
 	fromConfig.Renderer = nil
@@ -25,24 +24,22 @@ func relFileReport(ctx context.Context, c Config, path string) (map[string]binca
 		return nil, err
 	}
 	fromRelPath := map[string]bincapz.FileReport{}
-	for fname, f := range fromReport.Files {
+	for _, f := range fromReport.Files {
 		if f.Skipped != "" || f.Error != "" {
 			continue
 		}
-		logger.Info("file report", slog.String("file", fname), slog.Any("report", f))
+
 		rel, err := filepath.Rel(fromPath, f.Path)
 		if err != nil {
 			return nil, fmt.Errorf("rel(%q,%q): %w", fromPath, f.Path, err)
 		}
 		fromRelPath[rel] = f
-		logger.Info("relative file report", slog.String("relpath", rel), slog.Any("report", f))
 	}
 
 	return fromRelPath, nil
 }
 
 func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
-	clog.InfoContext(ctx, "diffing", slog.Any("scanpaths", c.ScanPaths))
 	if len(c.ScanPaths) != 2 {
 		return nil, fmt.Errorf("diff mode requires 2 paths, you passed in %d path(s)", len(c.ScanPaths))
 	}
@@ -190,11 +187,5 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 		}
 	}
 
-	clog.FromContext(ctx).Info("diff result", slog.Any("diff", d))
-
-	r := &bincapz.Report{
-		Diff: d,
-	}
-
-	return r, err
+	return &bincapz.Report{Diff: d}, err
 }

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -7,12 +7,10 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"log/slog"
 	"sort"
 	"strings"
 
 	"github.com/chainguard-dev/bincapz/pkg/bincapz"
-	"github.com/chainguard-dev/clog"
 	"github.com/olekukonko/tablewriter"
 )
 
@@ -120,7 +118,6 @@ func markdownTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc 
 		}
 
 		if len(k.Behavior.Values) > 0 {
-			clog.InfoContext(ctx, "", slog.String("description", k.Behavior.Description), slog.Any("values", k.Behavior.Values))
 			values := strings.Join(k.Behavior.Values, "\n")
 			before := " \""
 			after := "\""

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -58,7 +58,7 @@ func (r Markdown) Full(ctx context.Context, rep bincapz.Report) error {
 	return nil
 }
 
-func markdownTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc tableConfig) {
+func markdownTable(_ context.Context, fr *bincapz.FileReport, w io.Writer, rc tableConfig) {
 	path := fr.Path
 	if fr.Error != "" {
 		fmt.Printf("⚠️ %s - error: %s\n", path, fr.Error)

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -35,12 +35,11 @@ type tableConfig struct {
 	DiffAdded   bool
 }
 
-func forceWrap(_ context.Context, s string, x int) string {
+func forceWrap(s string, x int) string {
 	words, _ := tablewriter.WrapString(s, x)
 	fw := []string{}
 	for _, w := range words {
 		if len(w) > x-2 {
-			clog.Info("wrapping", slog.Any("word", w), slog.Int("length", len(w)), slog.Int("max", x-2))
 			w = w[0:x-2] + ".."
 		}
 		fw = append(fw, w)
@@ -188,7 +187,7 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 	maxKeyLen := 0
 
 	for _, k := range kbs {
-		key := forceWrap(ctx, k.Key, keyWidth)
+		key := forceWrap(k.Key, keyWidth)
 		if len(key) > maxKeyLen {
 			maxKeyLen = len(key)
 		}
@@ -198,8 +197,6 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 	if descWidth > 120 {
 		descWidth = 120
 	}
-
-	clog.InfoContext(ctx, "terminal width", slog.Int("width", tWidth), slog.Int("descWidth", descWidth))
 
 	for _, k := range kbs {
 		desc := k.Behavior.Description
@@ -215,11 +212,10 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 			}
 		}
 
-		key := forceWrap(ctx, k.Key, keyWidth)
+		key := forceWrap(k.Key, keyWidth)
 		words, _ := tablewriter.WrapString(desc, descWidth)
 		desc = strings.Join(words, "\n")
 		if len(k.Behavior.Values) > 0 {
-			clog.InfoContext(ctx, "Values", slog.String("description", k.Behavior.Description), slog.Any("values", k.Behavior.Values))
 			values := strings.Join(k.Behavior.Values, "\n")
 			before := " \""
 			after := "\""
@@ -227,7 +223,7 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 				before = "\n"
 				after = ""
 			}
-			desc = fmt.Sprintf("%s:%s%s%s", desc, before, forceWrap(ctx, strings.Join(k.Behavior.Values, "\n"), descWidth), after)
+			desc = fmt.Sprintf("%s:%s%s%s", desc, before, forceWrap(strings.Join(k.Behavior.Values, "\n"), descWidth), after)
 		}
 
 		// lowercase first character for consistency
@@ -265,7 +261,6 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 	}
 
 	tableWidth := maxKeyLen + maxDescWidth + padding + maxRiskWidth
-	clog.InfoContextf(ctx, "table width: %d", tableWidth)
 	fmt.Fprintf(w, "%s\n", strings.Repeat("-", tableWidth))
 	table.SetNoWhiteSpace(true)
 	table.SetTablePadding("  ")

--- a/pkg/rules/rules.go
+++ b/pkg/rules/rules.go
@@ -18,10 +18,6 @@ import (
 
 var FS = rules.FS
 
-var skipFiles = map[string]bool{
-	"third_party/Neo23x0/yara/configured_vulns_ext_vars.yar": true,
-}
-
 func Compile(ctx context.Context, root fs.FS, thirdParty bool) (*yara.Rules, error) {
 	yc, err := yara.NewCompiler()
 	if err != nil {
@@ -47,14 +43,7 @@ func Compile(ctx context.Context, root fs.FS, thirdParty bool) (*yara.Rules, err
 			return nil
 		}
 
-		if skipFiles[path] {
-			logger.Info("skipping (skipFiles)")
-			return nil
-		}
-
 		if !d.IsDir() && filepath.Ext(path) == ".yara" || filepath.Ext(path) == ".yar" {
-			logger.Info("reading")
-
 			bs, err := fs.ReadFile(root, path)
 			if err != nil {
 				return fmt.Errorf("readfile: %w", err)


### PR DESCRIPTION
Now that log messages are plumbed through in tests, it's difficult to distinguish the important messages from the unimportant ones.

This removes logs that haven't been useful in a while, and reduces the logging level for others that may still come in handy. It also nukes some dead code (`skipFiles`) that is no longer necessary now that we are using YARA Forge.