### PR TITLE
Update to YARAForge 2024-04-14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,5 +53,6 @@ test:
 
 .PHONY: update-yaraforge
 update-yaraforge:
+	mkdir -p out
 	curl -sL -o out/yaraforge.zip https://github.com/YARAHQ/yara-forge/releases/latest/download/yara-forge-rules-full.zip
 	unzip -o -j out/yaraforge.zip packages/full/yara-rules-full.yar -d rules/third_party/


### PR DESCRIPTION
Makefile was missing a `mkdir` for the `update-yaraforge` rule to work.

Rule changes:

```
+rule CAPE_Doomedloader : FILE
+rule ELCEEF_Polymorph_BAT_CAB : FILE
+rule SIGNATURE_BASE_SUSP_OBFUSC_SH_Indicators_Mar24_1 : FILE
+rule VOLEXITY_Apt_Malware_Py_Upstyle : UTA0218 FILE MEMORY
+rule VOLEXITY_Hacktool_Golang_Reversessh_Fahrj : FILE MEMORY
+rule VOLEXITY_Susp_Any_Jarischf_User_Path : FILE MEMORY
```
