### PR TITLE
terminal: dynamically scale output (again)

### DIFF
--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -19,7 +19,6 @@ import (
 	"golang.org/x/term"
 )
 
-
 var maxExampleCount = 8
 
 type KeyedBehavior struct {

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -19,6 +19,9 @@ import (
 	"golang.org/x/term"
 )
 
+
+var maxExampleCount = 8
+
 type KeyedBehavior struct {
 	Key      string
 	Behavior bincapz.Behavior
@@ -224,22 +227,33 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 
 	tWidth := terminalWidth(ctx)
 	keyWidth := 24
+	descWidth := 30
+	extraWidth := 12
+
+	if tWidth >= 100 {
+		keyWidth = 30
+		descWidth = 45
+	}
+
 	if tWidth >= 120 {
 		keyWidth = 32
+		descWidth = 54
 	}
-	maxEvidenceWidth := 0
+
+	maxEvidenceWidth := tWidth - keyWidth - extraWidth - descWidth
+	longestEvidence := 0
 
 	for _, k := range kbs {
 		for _, e := range k.Behavior.MatchStrings {
 			if len(e) > maxEvidenceWidth {
-				maxEvidenceWidth = len(e)
+				longestEvidence = maxEvidenceWidth
+				break
+			}
+
+			if len(e) > longestEvidence {
+				longestEvidence = len(e)
 			}
 		}
-	}
-
-	descWidth := tWidth - maxEvidenceWidth - keyWidth - 12
-	if descWidth > 54 {
-		descWidth = 54
 	}
 
 	for _, k := range kbs {
@@ -255,7 +269,19 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 				desc = fmt.Sprintf("by %s", k.Behavior.RuleAuthor)
 			}
 		}
-		evidence := strings.Join(k.Behavior.MatchStrings, "\n")
+
+		abbreviatedEv := []string{}
+		for _, e := range k.Behavior.MatchStrings {
+			if len(e) > maxEvidenceWidth {
+				e = e[0:maxEvidenceWidth-1] + "…"
+			}
+			abbreviatedEv = append(abbreviatedEv, e)
+			if len(abbreviatedEv) >= maxExampleCount {
+				abbreviatedEv = append(abbreviatedEv, "…")
+				break
+			}
+		}
+		evidence := strings.Join(abbreviatedEv, "\n")
 
 		risk := riskColor(ShortRisk(k.Behavior.RiskLevel))
 		if k.Behavior.DiffAdded || rc.DiffAdded {


### PR DESCRIPTION
As part of #143 I ripped out dynamic terminal scaling to simplify adding the evidence field into the output. This adds it back, albeit a little smaller:

* Truncate evidence to fit the terminal width
* Increase key/desc with slightly at 100 characters
* Only show the first 8 matching evidence samples for a keyword

## Previous terminal output @ 80 chars

![Screenshot from 2024-04-22 20-36-13](https://github.com/chainguard-dev/bincapz/assets/101424/f81d2e3e-754a-4efb-a28f-7acb7e8f937e)

## New terminal output @ 80 chars

![Screenshot from 2024-04-22 20-33-21](https://github.com/chainguard-dev/bincapz/assets/101424/2a373a10-c87a-4e06-aaa8-316e4fa13d0e)
