### PR TITLE
Ignore bincapz findings by default

### DIFF
--- a/bincapz.go
+++ b/bincapz.go
@@ -20,18 +20,19 @@ import (
 )
 
 func main() {
-	formatFlag := flag.String("format", "terminal", "Output type. Valid values are: json, markdown, simple, terminal, yaml")
-	ignoreTagsFlag := flag.String("ignore-tags", "", "Rule tags to ignore")
-	minLevelFlag := flag.Int("min-level", 1, "minimum risk level to show results for (1=low, 2=medium, 3=high, 4=critical)")
-	minFileLevelFlag := flag.Int("min-file-level", 0, "only show results for files that meet this risk level (1=low, 2=medium, 3=high, 4=critical)")
-	thirdPartyFlag := flag.Bool("third-party", true, "include third-party rules, which may have licensing restrictions")
-	omitEmptyFlag := flag.Bool("omit-empty", false, "omit files that contain no matches")
-	includeDataFilesFlag := flag.Bool("data-files", false, "include files that are detected to as non-program (binary or source) files")
-	diffFlag := flag.Bool("diff", false, "show capability drift between two files")
 	allFlag := flag.Bool("all", false, "Ignore nothing, show all")
-	statsFlag := flag.Bool("stats", false, "show statistics about the scan")
-	verboseFlag := flag.Bool("verbose", false, "emit verbose logging messages to stderr")
+	diffFlag := flag.Bool("diff", false, "show capability drift between two files")
+	formatFlag := flag.String("format", "terminal", "Output type. Valid values are: json, markdown, simple, terminal, yaml")
+	ignoreSelfFlag := flag.Bool("ignore-self", true, "ignore the bincapz repository")
+	ignoreTagsFlag := flag.String("ignore-tags", "", "Rule tags to ignore")
+	includeDataFilesFlag := flag.Bool("data-files", false, "include files that are detected to as non-program (binary or source) files")
+	minFileLevelFlag := flag.Int("min-file-level", 0, "only show results for files that meet this risk level (1=low, 2=medium, 3=high, 4=critical)")
+	minLevelFlag := flag.Int("min-level", 1, "minimum risk level to show results for (1=low, 2=medium, 3=high, 4=critical)")
 	ociFlag := flag.Bool("oci", false, "scan an OCI image")
+	omitEmptyFlag := flag.Bool("omit-empty", false, "omit files that contain no matches")
+	statsFlag := flag.Bool("stats", false, "show statistics about the scan")
+	thirdPartyFlag := flag.Bool("third-party", true, "include third-party rules, which may have licensing restrictions")
+	verboseFlag := flag.Bool("verbose", false, "emit verbose logging messages to stderr")
 
 	flag.Parse()
 	args := flag.Args()
@@ -75,15 +76,16 @@ func main() {
 	}
 
 	bc := action.Config{
+		IgnoreSelf:       *ignoreSelfFlag,
+		IgnoreTags:       ignoreTags,
+		IncludeDataFiles: includeDataFiles,
+		MinFileScore:     *minFileLevelFlag,
+		MinResultScore:   minLevel,
+		OCI:              *ociFlag,
+		OmitEmpty:        *omitEmptyFlag,
+		Renderer:         renderer,
 		Rules:            yrs,
 		ScanPaths:        args,
-		IgnoreTags:       ignoreTags,
-		OmitEmpty:        *omitEmptyFlag,
-		MinResultScore:   minLevel,
-		MinFileScore:     *minFileLevelFlag,
-		IncludeDataFiles: includeDataFiles,
-		Renderer:         renderer,
-		OCI:              *ociFlag,
 		Stats:            stats,
 	}
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -11,15 +11,16 @@ import (
 )
 
 type Config struct {
+	IgnoreSelf       bool
+	IgnoreTags       []string
+	IncludeDataFiles bool
+	MinFileScore     int
+	MinResultScore   int
+	OCI              bool
+	OmitEmpty        bool
+	Output           io.Writer
+	Renderer         render.Renderer
 	Rules            *yara.Rules
 	ScanPaths        []string
-	IgnoreTags       []string
-	MinResultScore   int
-	MinFileScore     int
-	OmitEmpty        bool
-	IncludeDataFiles bool
-	Renderer         render.Renderer
-	Output           io.Writer
-	OCI              bool
 	Stats            bool
 }

--- a/rules/bincapz/bincapz.yar
+++ b/rules/bincapz/bincapz.yar
@@ -1,0 +1,8 @@
+rule bincapz_path : harmless {
+    meta:
+        description = "path reference containing bincapz binary"
+    strings:
+        $path = "bincapz"
+    condition:
+        none of them
+}

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -65,10 +65,11 @@ func TestJSON(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 			bc := action.Config{
-				ScanPaths:  []string{binPath},
+				IgnoreSelf: false,
 				IgnoreTags: []string{"harmless"},
 				Renderer:   render,
 				Rules:      yrs,
+				ScanPaths:  []string{binPath},
 			}
 
 			tcLogger := clog.FromContext(ctx).With("test", name)
@@ -123,10 +124,11 @@ func TestSimple(t *testing.T) {
 			}
 
 			bc := action.Config{
-				ScanPaths:  []string{binPath},
+				IgnoreSelf: false,
 				IgnoreTags: []string{"harmless"},
 				Renderer:   simple,
 				Rules:      yrs,
+				ScanPaths:  []string{binPath},
 			}
 
 			tcLogger := clog.FromContext(ctx).With("test", name)
@@ -190,12 +192,13 @@ func TestDiff(t *testing.T) {
 			}
 
 			bc := action.Config{
-				ScanPaths:      []string{tc.src, tc.dest},
+				IgnoreSelf:     false,
 				IgnoreTags:     []string{"harmless"},
+				MinFileScore:   tc.minFileScore,
+				MinResultScore: tc.minResultScore,
 				Renderer:       simple,
 				Rules:          yrs,
-				MinResultScore: tc.minResultScore,
-				MinFileScore:   tc.minFileScore,
+				ScanPaths:      []string{tc.src, tc.dest},
 			}
 
 			logger := clog.New(slog.Default().Handler()).With("src", tc.src)
@@ -253,10 +256,11 @@ func TestMarkdown(t *testing.T) {
 			}
 
 			bc := action.Config{
-				ScanPaths:  []string{binPath},
+				IgnoreSelf: false,
 				IgnoreTags: []string{"harmless"},
 				Renderer:   simple,
 				Rules:      yrs,
+				ScanPaths:  []string{binPath},
 			}
 
 			tcLogger := clog.FromContext(ctx).With("test", name)


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/134

This PR ignores `bincapz` findings by default (which can be overridden with `--ignore-self=false`) while also allowing the current test cases to pass (using `IgnoreSelf: false`).

There are two methods for ignoring the findings in this PR:
- if the absolute directory path contains `bincapz`, ignore adding the file to the list of files to scan
- a new YARA rule ignoring `bincapz`

Example of running the rule against the compiled `bincapz` binary:
```
❯ go run . ~/Downloads/bincapz

```

versus:
```
❯ go run . --ignore-self=false --format simple ~/Downloads/bincapz
# /Users/egibs/Downloads/bincapz
3P/arkbird/solg/backdoor/nazar
3P/arkbird/solg/envyscout/may
3P/avastti/cobaltstrike/beacon
3P/avastti/cobaltstrike/payload
3P/binaryalert/bella
3P/binaryalert/eicar/substring/test
3P/binaryalert/hacktool/exploit/cve
3P/binaryalert/hacktool/exploit/tpwn
3P/binaryalert/hacktool/juuso/keychaindump
3P/binaryalert/hacktool/keylogger/b4rsby
3P/binaryalert/hacktool/keylogger/caseyscarborough
3P/binaryalert/hacktool/keylogger/dannvix
3P/binaryalert/hacktool/keylogger/eldeveloper
3P/binaryalert/hacktool/keylogger/giacomolaw
3P/binaryalert/hacktool/keylogger/logkext
3P/binaryalert/hacktool/keylogger/roxlu
3P/binaryalert/hacktool/keylogger/skreweverything
3P/binaryalert/hacktool/macpmem
3P/binaryalert/hacktool/manwhoami/icloudcontacts
3P/binaryalert/hacktool/manwhoami/mmetokendecrypt
3P/binaryalert/hacktool/manwhoami/osxchromedecrypt
3P/binaryalert/hacktool/multi/bloodhound
3P/binaryalert/hacktool/multi/jtesta
3P/binaryalert/hacktool/multi/masscan
3P/binaryalert/hacktool/multi/ncc
3P/binaryalert/hacktool/multi/ntlmrelayx
3P/binaryalert/hacktool/multi/pyrasite
3P/binaryalert/hacktool/multi/responder
3P/binaryalert/hacktool/n0fate/chainbreaker
3P/binaryalert/hacktool/ptoomey3/keychain
3P/binaryalert/hacktool/windows/hot
3P/binaryalert/hacktool/windows/mimikatz
3P/binaryalert/hacktool/windows/moyix
3P/binaryalert/hacktool/windows/ncc
3P/binaryalert/hacktool/windows/rdp
3P/binaryalert/hacktool/windows/wmi
3P/binaryalert/marten4n6/evilosx
3P/binaryalert/multi/pupy/rat
3P/binaryalert/multi/vesche/basicrat
3P/binaryalert/neoneggplant/eggshell
3P/binaryalert/proton/rat
3P/binaryalert/ransomware/windows/cerber
3P/binaryalert/ransomware/windows/cryptolocker
3P/binaryalert/ransomware/windows/hddcryptora
3P/binaryalert/ransomware/windows/petya
3P/binaryalert/ransomware/windows/powerware
3P/binaryalert/ransomware/windows/wannacry
3P/binaryalert/ransomware/windows/zcrypt
3P/binaryalert/sofacy/xagent
3P/binaryalert/windows/moonlightmaze/cle
3P/binaryalert/windows/moonlightmaze/custom
3P/binaryalert/windows/moonlightmaze/de
3P/binaryalert/windows/moonlightmaze/loki
3P/binaryalert/windows/moonlightmaze/xk
3P/binaryalert/windows/pony/stealer
3P/binaryalert/windows/red/leaves
3P/binaryalert/windows/remcos/rat
3P/binaryalert/windows/t3ntman/crunchrat
3P/binaryalert/windows/whitebear/binary
3P/binaryalert/windows/winnti/loadperf
3P/binaryalert/windows/xrat/quasarrat
3P/cape
3P/cape/agent/tesla
3P/cape/trickbot
3P/cape/trickbot/permadll/uefi
3P/cod3nym/susp/obf/pyarmor
3P/ditekshen/amcpcvark
3P/ditekshen/dazzlespy
3P/ditekshen/exe/references/publicserviceinterface
3P/ditekshen/genieo
3P/ditekshen/java/packed/allatori
3P/ditekshen/java/pyrogenic
3P/ditekshen/js/wmi/execquery
3P/ditekshen/kb/id/powershellcookiestealer
3P/ditekshen/kb/id/powershellwifistealer
3P/ditekshen/kb/id/ransomware
3P/ditekshen/macsearch
3P/ditekshen/maxofferdeal
3P/ditekshen/pws/capturebrowserplugins
3P/ditekshen/pws/capturescreenshot
3P/ditekshen/pwsh/cumii
3P/ditekshen/pwsh/passwordcredential/retrievepassword
3P/ditekshen/realtimespy
3P/ditekshen/techyutils
3P/ditekshen/tool/avbypass/aviator
3P/ditekshen/tool/cnc/earthworm
3P/ditekshen/tool/exp/eternalblue
3P/ditekshen/tool/goclr
3P/ditekshen/tool/ligolo
3P/ditekshen/tool/ngrok
3P/ditekshen/tool/pet/mulit
3P/ditekshen/tool/pws
3P/ditekshen/tool/pws/keychaindumper
3P/ditekshen/tool/sliver
3P/ditekshen/win
3P/ditekshen/win/asyncrat
3P/ditekshen/win/blankstealer
3P/ditekshen/win/dcrat
3P/ditekshen/win/egregor
3P/ditekshen/win/grum
3P/ditekshen/win/hunt/apostle
3P/ditekshen/win/masslogger
3P/ditekshen/win/megumin
3P/ditekshen/win/mystic
3P/ditekshen/win/nglite
3P/ditekshen/win/osno
3P/ditekshen/win/phoenix
3P/ditekshen/win/pwsh/poshcookiestealer
3P/ditekshen/win/pwsh/poshkeylogger
3P/ditekshen/win/pwsh/poshwifistealer
3P/ditekshen/win/pwshloader
3P/ditekshen/win/quantum
3P/ditekshen/win/quilclipper
3P/ditekshen/win/qulab
3P/ditekshen/win/satana
3P/ditekshen/win/sweetystealer
3P/ditekshen/win/taurus
3P/ditekshen/win/vbs
3P/ditekshen/windtrail
3P/dragon/threat/labs/c16
3P/elastic/backdoor/fakeflashlxk
3P/elastic/backdoor/fontonlake
3P/elastic/backdoor/kagent
3P/elastic/backdoor/keyboardrecord
3P/elastic/backdoor/tinyshell
3P/elastic/backdoor/useragent
3P/elastic/bpfdoor
3P/elastic/cryptominer
3P/elastic/cryptominer/xmrig
3P/elastic/eggshell
3P/elastic/electrorat
3P/elastic/exploit
3P/elastic/exploit/cve/2021
3P/elastic/exploit/cve/2022
3P/elastic/hacktool/bifrost
3P/elastic/hacktool/fontonlake
3P/elastic/hacktool/jokerspy
3P/elastic/hacktool/lightning
3P/elastic/hacktool/swiftbelt
3P/elastic/hacktool/wipelog
3P/elastic/kandykorn
3P/elastic/metasploit
3P/elastic/mirai
3P/elastic/multi/coreimpact
3P/elastic/multi/hacktool/nps
3P/elastic/multi/hacktool/rakshasa
3P/elastic/multi/mythic
3P/elastic/multi/ransomware/blackcat
3P/elastic/multi/ransomware/luna
3P/elastic/multi/sliver
3P/elastic/orbit
3P/elastic/proxy/frp
3P/elastic/ransomware/akira
3P/elastic/ransomware/blacksuit
3P/elastic/ransomware/clop
3P/elastic/ransomware/conti
3P/elastic/ransomware/erebus
3P/elastic/ransomware/esxiargs
3P/elastic/ransomware/hellokitty
3P/elastic/ransomware/limpdemon
3P/elastic/ransomware/lockbit
3P/elastic/ransomware/monti
3P/elastic/ransomware/noescape
3P/elastic/ransomware/quantum
3P/elastic/ransomware/ragnarlocker
3P/elastic/ransomware/royalpest
3P/elastic/rootkit/fontonlake
3P/elastic/rustbucket
3P/elastic/thiefquest
3P/elastic/windows
3P/elastic/windows/afdk
3P/elastic/windows/agenttesla
3P/elastic/windows/backdoor/teamviewer
3P/elastic/windows/backoff
3P/elastic/windows/bandook
3P/elastic/windows/behinder
3P/elastic/windows/bitrat
3P/elastic/windows/bruteratel
3P/elastic/windows/bughatch
3P/elastic/windows/carberp
3P/elastic/windows/cobaltstrike
3P/elastic/windows/cybergate
3P/elastic/windows/darkcomet
3P/elastic/windows/darkgate
3P/elastic/windows/dcrat
3P/elastic/windows/doorme
3P/elastic/windows/doubleback
3P/elastic/windows/downtown
3P/elastic/windows/dridex
3P/elastic/windows/exploit/dcom
3P/elastic/windows/flawedgrace
3P/elastic/windows/gh0st
3P/elastic/windows/gozi
3P/elastic/windows/guloader
3P/elastic/windows/hacktool
3P/elastic/windows/hacktool/askcreds
3P/elastic/windows/hacktool/clroxide
3P/elastic/windows/hacktool/darkloadlibrary
3P/elastic/windows/hacktool/mimikatz
3P/elastic/windows/hacktool/rubeus
3P/elastic/windows/hacktool/safetykatz
3P/elastic/windows/hacktool/seatbelt
3P/elastic/windows/hacktool/sharpapplocker
3P/elastic/windows/hacktool/sharpchromium
3P/elastic/windows/hacktool/sharpdump
3P/elastic/windows/hacktool/sharpersist
3P/elastic/windows/hacktool/sharphound
3P/elastic/windows/hacktool/sharplaps
3P/elastic/windows/hacktool/sharpmove
3P/elastic/windows/hacktool/sharprdp
3P/elastic/windows/hacktool/sharpshares
3P/elastic/windows/hacktool/sharpstay
3P/elastic/windows/hacktool/sharpup
3P/elastic/windows/hacktool/sharpview
3P/elastic/windows/hacktool/sharpwmi
3P/elastic/windows/hacktool/winpeas
3P/elastic/windows/hancitor
3P/elastic/windows/hawkeye
3P/elastic/windows/hazelcobra
3P/elastic/windows/icedid
3P/elastic/windows/jupyter
3P/elastic/windows/kronos
3P/elastic/windows/lokibot
3P/elastic/windows/metasploit
3P/elastic/windows/modpipe
3P/elastic/windows/nanocore
3P/elastic/windows/naplistener
3P/elastic/windows/netwire
3P/elastic/windows/nimplant
3P/elastic/windows/onlylogger
3P/elastic/windows/pandastealer
3P/elastic/windows/parallax
3P/elastic/windows/pingpull
3P/elastic/windows/powerseal
3P/elastic/windows/pup
3P/elastic/windows/pup/mediaarena
3P/elastic/windows/qbot
3P/elastic/windows/ransomware
3P/elastic/windows/ransomware/bitpaymer
3P/elastic/windows/ransomware/blackbasta
3P/elastic/windows/ransomware/blackhunt
3P/elastic/windows/ransomware/clop
3P/elastic/windows/ransomware/dharma
3P/elastic/windows/ransomware/egregor
3P/elastic/windows/ransomware/helloxd
3P/elastic/windows/ransomware/hive
3P/elastic/windows/ransomware/ragnarok
3P/elastic/windows/ransomware/snake
3P/elastic/windows/ransomware/thanos
3P/elastic/windows/redlinestealer
3P/elastic/windows/remcos
3P/elastic/windows/revcoderat
3P/elastic/windows/shadowpad
3P/elastic/windows/snakekeylogger
3P/elastic/windows/squirrelwaffle
3P/elastic/windows/stealc
3P/elastic/windows/strrat
3P/elastic/windows/svcready
3P/elastic/windows/sysjoker
3P/elastic/windows/sythe
3P/elastic/windows/trickbot
3P/elastic/windows/virus/neshta
3P/elastic/windows/xworm
3P/elastic/xzbackdoor
3P/elastic/zerobot
3P/embeeresearch/win/berbew/strings
3P/embeeresearch/win/orcus/rat
3P/embeeresearch/win/remcos/rat
3P/embeeresearch/win/ursnif/patterns
3P/eset/dino
3P/eset/iis
3P/eset/keydnap/backdoor
3P/eset/keydnap/downloader
3P/eset/kobalos/ssh/credential
3P/eset/rakos
3P/eset/sparklinggoblin/mutex
3P/eset/stantinko
3P/eset/stantinko/wsaudio
3P/eset/turla/outlook/filenames
3P/eset/turla/outlook/gen
3P/eset/windows/ta410/x4
3P/fireeye/rt/b64engine/dotnettojscript
3P/fireeye/rt/backdoor/gorat
3P/fireeye/rt/backdoor/ps1
3P/fireeye/rt/backdoor/win
3P/fireeye/rt/builder/py
3P/fireeye/rt/gadgettojscript
3P/fireeye/rt/macro/resumeplease
3P/gcti/cobaltstrike/resources/template
3P/jpcertcc/elf/plead
3P/jpcertcc/himawari
3P/jpcertcc/nanocore
3P/jpcertcc/netwire
3P/jpcertcc/noderat
3P/jpcertcc/remcos
3P/jpcertcc/ursnif
3P/jpcertcc/xxmm
3P/microsoft/win32/adupib
3P/microsoft/win32/plaplex
3P/ncsc/sparrowdoor/strings
3P/r3c0nst/exploit/outlook/cve
3P/russianpanda/fakebat/powershell
3P/russianpanda/win/koistealer/ps
3P/russianpanda/win/sus/internetshortcutfile
3P/sbousseaden/adsync/creddump/wide
3P/sbousseaden/adsync/creddump/xor
3P/sbousseaden/hunt/credaccess/iis
3P/sbousseaden/mem/webcreds/regexp
3P/secuinfra/ransom/esxiargs/ransomware
3P/secuinfra/susp/powershell/download
3P/secuinfra/susp/scheduled/tasks
3P/signature_base
3P/signature_base/ajan/asp
3P/signature_base/ajax/php
3P/signature_base/ak74shell/php
3P/signature_base/ammyy/admin
3P/signature_base/angry/ip
3P/signature_base/antichat/shell
3P/signature_base/antichat/socks5
3P/signature_base/apt15
3P/signature_base/apt28/drovorub
3P/signature_base/apt29/nobelium
3P/signature_base/apt34/ps
3P/signature_base/apt41/cn
3P/signature_base/arttrayhookdll
3P/signature_base/asmodeus/v0
3P/signature_base/aspack/chinese
3P/signature_base/aspydrv/asp
3P/signature_base/ayyildiz/tim
3P/signature_base/azrailphp/v1
3P/signature_base/backdoor/bella
3P/signature_base/backdoor/redosdru
3P/signature_base/backdoor/win
3P/signature_base/backdoor1/php
3P/signature_base/backdoorfr/php
3P/signature_base/base64/ps1
3P/signature_base/batch/powershell
3P/signature_base/batch/script
3P/signature_base/beastdoor/backdoor
3P/signature_base/bernhardpos
3P/signature_base/bin/client
3P/signature_base/bin/server
3P/signature_base/binder2
3P/signature_base/bitchin/threads
3P/signature_base/bkdr/xzutil
3P/signature_base/bluenoroffpos/dll
3P/signature_base/bluesportscan
3P/signature_base/builder/py
3P/signature_base/by063cli
3P/signature_base/by064cli
3P/signature_base/bypassfirewall/zip
3P/signature_base/byshell063/ntboot
3P/signature_base/c99madshell/v2
3P/signature_base/cachedump
3P/signature_base/cactustorch
3P/signature_base/camarodragon/horseshell
3P/signature_base/camarodragon/sheel
3P/signature_base/casper/included
3P/signature_base/casper/systeminformation
3P/signature_base/casus15/php
3P/signature_base/cgi/python
3P/signature_base/cleaniislog
3P/signature_base/clearlog
3P/signature_base/cmdasp/asp
3P/signature_base/cmdjsp/jsp
3P/signature_base/cn/hacktool
3P/signature_base/cn/reddelta
3P/signature_base/cn/toolset
3P/signature_base/cn/wocao
3P/signature_base/cn/zerot
3P/signature_base/cobaltgang/pdf
3P/signature_base/cobaltstrike/unmodifed
3P/signature_base/codoso/customtcp
3P/signature_base/codoso/gh0st
3P/signature_base/codoso/pgv
3P/signature_base/commentcrew/miniasp
3P/signature_base/connectback2/pl
3P/signature_base/connector
3P/signature_base/connectwise/screenconnect
3P/signature_base/coreimpact/sysdll
3P/signature_base/crack/loader
3P/signature_base/credtheft/msil
3P/signature_base/csh/php
3P/signature_base/custom/ssh
3P/signature_base/cyberlords/sql
3P/signature_base/dbgntboot
3P/signature_base/debug/cress
3P/signature_base/deeppanda
3P/signature_base/deeppanda/htran
3P/signature_base/disclosed/0day
3P/signature_base/dive/shell
3P/signature_base/dnscat2/hacktool
3P/signature_base/dtrack
3P/signature_base/dx/php
3P/signature_base/editkeylog
3P/signature_base/editkeylogreadme
3P/signature_base/editserver
3P/signature_base/editserver/exe
3P/signature_base/efso/2
3P/signature_base/elf/saltwater
3P/signature_base/elmaliseker
3P/signature_base/elmaliseker/asp
3P/signature_base/empire/get
3P/signature_base/empire/invoke
3P/signature_base/empire/keepassconfig
3P/signature_base/empire/powershell
3P/signature_base/empire/powerup
3P/signature_base/eqgrp/bananaaid
3P/signature_base/eqgrp/bananausurper
3P/signature_base/eqgrp/barpunch
3P/signature_base/eqgrp/bball
3P/signature_base/eqgrp/bflea
3P/signature_base/eqgrp/bicecream
3P/signature_base/eqgrp/bliar
3P/signature_base/eqgrp/busurper
3P/signature_base/eqgrp/callbacks
3P/signature_base/eqgrp/config
3P/signature_base/eqgrp/create
3P/signature_base/eqgrp/eligiblecandidate
3P/signature_base/eqgrp/epba
3P/signature_base/eqgrp/epicbanana
3P/signature_base/eqgrp/extrabacon
3P/signature_base/eqgrp/implants
3P/signature_base/eqgrp/jetplow
3P/signature_base/eqgrp/mixtext
3P/signature_base/eqgrp/networkprofiler
3P/signature_base/eqgrp/pandarock
3P/signature_base/eqgrp/payload
3P/signature_base/eqgrp/screamingplow
3P/signature_base/eqgrp/sniffer
3P/signature_base/eqgrp/sploit
3P/signature_base/eqgrp/ssh
3P/signature_base/eqgrp/storefc
3P/signature_base/eqgrp/tinyhttp
3P/signature_base/eqgrp/tunnel
3P/signature_base/eqgrp/uninstallpbd
3P/signature_base/eqgrp/unique
3P/signature_base/eqgrp/userscript
3P/signature_base/eqgrp/workit
3P/signature_base/equation/equationlaser
3P/signature_base/equation/group
3P/signature_base/equationdrug/hddssd
3P/signature_base/equationgroup
3P/signature_base/equationgroup/cmsd
3P/signature_base/equationgroup/cmsex
3P/signature_base/equationgroup/dul
3P/signature_base/equationgroup/ebbshave
3P/signature_base/equationgroup/eggbasket
3P/signature_base/equationgroup/elgingamble
3P/signature_base/equationgroup/epoxyresin
3P/signature_base/equationgroup/estesfox
3P/signature_base/equationgroup/ftshell
3P/signature_base/equationgroup/ghost
3P/signature_base/equationgroup/jackpop
3P/signature_base/equationgroup/jparsescan
3P/signature_base/equationgroup/sambal
3P/signature_base/equationgroup/scanner
3P/signature_base/equationgroup/toolset
3P/signature_base/eternalrocks/taskhost
3P/signature_base/expl/gitlab
3P/signature_base/expl/log
3P/signature_base/expl/log4j
3P/signature_base/expl/manageengine
3P/signature_base/expl/poc
3P/signature_base/expl/shitrix
3P/signature_base/ext/apt32
3P/signature_base/ext/susp
3P/signature_base/felikspack3/php
3P/signature_base/felikspack3/scanners
3P/signature_base/fgexec
3P/signature_base/fidelis/advisory
3P/signature_base/fin7/backdoor
3P/signature_base/fin7/strings
3P/signature_base/fiveeyes/querty
3P/signature_base/fourelementsword/config
3P/signature_base/fourelementsword/elevatedll
3P/signature_base/fshttp/fspop
3P/signature_base/fso/s
3P/signature_base/fuckphpshell/php
3P/signature_base/fvey/shadowbroker
3P/signature_base/ghostdragon/gh0strat
3P/signature_base/gina/zip
3P/signature_base/github/repo
3P/signature_base/grace
3P/signature_base/greenbug
3P/signature_base/grizzly/steppe
3P/signature_base/h4ntu/shell
3P/signature_base/hacktool/samples
3P/signature_base/hacktools/cn
3P/signature_base/hafnium/forensic
3P/signature_base/hawkeye/keylogger
3P/signature_base/hdconfig
3P/signature_base/hellsing/implantstrings
3P/signature_base/hkdoordll
3P/signature_base/hkshell/hkrmv
3P/signature_base/hkshell/hkshell
3P/signature_base/hktl/amplia
3P/signature_base/hktl/cobaltstrike
3P/signature_base/hktl/dsniff
3P/signature_base/hktl/khepri
3P/signature_base/hktl/lazagne
3P/signature_base/hktl/lazycat
3P/signature_base/hktl/natbypass
3P/signature_base/hktl/nishang
3P/signature_base/hktl/nopowershell
3P/signature_base/hktl/portscanner
3P/signature_base/hktl/powerkatz
3P/signature_base/hktl/ps1
3P/signature_base/hktl/python
3P/signature_base/hktl/unknown
3P/signature_base/hktl/venom
3P/signature_base/hp/ilo
3P/signature_base/http/exe
3P/signature_base/hvs/apt27
3P/signature_base/hytop/caseswitch
3P/signature_base/hytop/devpack
3P/signature_base/hytop2006/rar
3P/signature_base/icyfox007v1/10
3P/signature_base/ikat/command
3P/signature_base/ikat/startbar
3P/signature_base/impacket/tools
3P/signature_base/implant/3
3P/signature_base/implant/4
3P/signature_base/industroyer
3P/signature_base/industroyer/portscan
3P/signature_base/installer
3P/signature_base/instgina
3P/signature_base/invoke/mimikatz
3P/signature_base/invoke/mimikittenz
3P/signature_base/invoke/osiris
3P/signature_base/invoke/wmiexec
3P/signature_base/ip/stealing
3P/signature_base/irongate/step7prosim
3P/signature_base/ironpanda/dnstunclient
3P/signature_base/ironpanda/htran
3P/signature_base/ironshell/php
3P/signature_base/irontiger/aspxspy
3P/signature_base/irontiger/wmiexec
3P/signature_base/java/shell
3P/signature_base/javascript/run
3P/signature_base/jc/wineggdrop
3P/signature_base/js/mshta
3P/signature_base/jsp/reverse
3P/signature_base/jspshall/jsp
3P/signature_base/jspwebshell/1
3P/signature_base/kacak/asp
3P/signature_base/kerberoast/py
3P/signature_base/keylogger/cn
3P/signature_base/kins/dropper
3P/signature_base/lamashell/php
3P/signature_base/lazagne/pw
3P/signature_base/linadoor/rootkit
3P/signature_base/linuxhacktool/eyes
3P/signature_base/liudoor
3P/signature_base/liz0zim/private
3P/signature_base/log/exchange
3P/signature_base/log/expl
3P/signature_base/log/f5
3P/signature_base/log/proxynotshell
3P/signature_base/log/teamviewer
3P/signature_base/log/webshell
3P/signature_base/lsremora
3P/signature_base/lua/lua
3P/signature_base/lurm/safemod
3P/signature_base/merlinagent
3P/signature_base/metasploit/loader
3P/signature_base/microcin/sample
3P/signature_base/mimikatz/logfile
3P/signature_base/mimipenguin/sh
3P/signature_base/mithril/dlltest
3P/signature_base/mithril/mithril
3P/signature_base/mithril/v1
3P/signature_base/ms08/067
3P/signature_base/msbuild/mimikatz
3P/signature_base/msfpayloads/msf
3P/signature_base/multiple/php
3P/signature_base/mysql/shell
3P/signature_base/mysql/web
3P/signature_base/nanocore/rat
3P/signature_base/nautilus/forensic
3P/signature_base/ncat/hacktools
3P/signature_base/ncrack
3P/signature_base/netbios/name
3P/signature_base/netview/hacktool
3P/signature_base/network/php
3P/signature_base/ngh/php
3P/signature_base/nixrem/php
3P/signature_base/nk/3cx
3P/signature_base/nk/dll
3P/signature_base/nst/php
3P/signature_base/nt/addy
3P/signature_base/ntlm/dump
3P/signature_base/oilrig/campaign
3P/signature_base/oilrig/intelsecuritymanager
3P/signature_base/onhat/proxy
3P/signature_base/opcleaver
3P/signature_base/opcleaver/antivirusdetector
3P/signature_base/opcleaver/backdoorlogger
3P/signature_base/opcleaver/ccproxy
3P/signature_base/opcleaver/csext
3P/signature_base/opcleaver/jasus
3P/signature_base/opcleaver/kagent
3P/signature_base/opcleaver/mimikatzwrapper
3P/signature_base/opcleaver/pvz
3P/signature_base/opcleaver/synflooder
3P/signature_base/opcleaver/tinyzbot
3P/signature_base/opcleaver/zhlookup
3P/signature_base/opcleaver/zhmimikatz
3P/signature_base/opcleaver/zhoupinexploitcrew
3P/signature_base/opcloudhopper
3P/signature_base/opcloudhopper/wmidll
3P/signature_base/p0wnedamsibypass
3P/signature_base/p0wnedbinaries
3P/signature_base/p0wnedexploits
3P/signature_base/p0wnedpotato
3P/signature_base/p0wnedpowercat
3P/signature_base/p0wnedshell/outputs
3P/signature_base/passcv/sabre
3P/signature_base/passsniffer
3P/signature_base/passsniffer/zip
3P/signature_base/passwordreminder
3P/signature_base/pastebin/webshell
3P/signature_base/payload
3P/signature_base/perlbot/pl
3P/signature_base/phantasma/php
3P/signature_base/php/backdoor
3P/signature_base/php/cloaked
3P/signature_base/php/include
3P/signature_base/php/php
3P/signature_base/php/shell
3P/signature_base/php/webshell
3P/signature_base/phpinj/php
3P/signature_base/phpjackal/php
3P/signature_base/phpshell17/php
3P/signature_base/phvayvv/php
3P/signature_base/phyton/shell
3P/signature_base/pirpi/1609
3P/signature_base/plugx/j16
3P/signature_base/plugx/redleaves
3P/signature_base/poisonivy/sample
3P/signature_base/portracer
3P/signature_base/portscan
3P/signature_base/portscan/shark
3P/signature_base/poseidongroup
3P/signature_base/poshspy
3P/signature_base/potplayer/dll
3P/signature_base/power/pe
3P/signature_base/powershdll
3P/signature_base/powershell/isesteroids
3P/signature_base/powershell/netcat
3P/signature_base/pp/cn
3P/signature_base/processinjector/gen
3P/signature_base/project/sauron
3P/signature_base/promethium/neodymium
3P/signature_base/proport/zip
3P/signature_base/proxy/packed
3P/signature_base/ps/amsi
3P/signature_base/ps1/toolkit
3P/signature_base/pscan/portscan
3P/signature_base/pstgdump
3P/signature_base/pupy/backdoor
3P/signature_base/pupyrat/py
3P/signature_base/putterpanda/rel
3P/signature_base/pwdump
3P/signature_base/py/dimorf
3P/signature_base/py/esxi
3P/signature_base/qa/vqgk
3P/signature_base/quarkspwdump/gen
3P/signature_base/quasar/rat
3P/signature_base/r577/php
3P/signature_base/r57shell/php
3P/signature_base/ransom/crime
3P/signature_base/ransom/darkbit
3P/signature_base/ransom/darkside
3P/signature_base/ransom/elf
3P/signature_base/ransom/lockbit
3P/signature_base/ransom/sh
3P/signature_base/rat
3P/signature_base/rat/adwind
3P/signature_base/rat/adzok
3P/signature_base/rat/ap0calypse
3P/signature_base/rat/blackshades
3P/signature_base/rat/bluebanana
3P/signature_base/rat/bozok
3P/signature_base/rat/clientmesh
3P/signature_base/rat/darkcomet
3P/signature_base/rat/darkrat
3P/signature_base/rat/lostdoor
3P/signature_base/rat/paradox
3P/signature_base/rat/qrat
3P/signature_base/rat/shadowtech
3P/signature_base/rat/unrecom
3P/signature_base/rat/vertex
3P/signature_base/rdp/brute
3P/signature_base/reader/asp
3P/signature_base/redleaves/coreimplant
3P/signature_base/redmenshen/bpfdoor
3P/signature_base/redsails/py
3P/signature_base/reflective/dll
3P/signature_base/regin/related
3P/signature_base/rehashed/rat
3P/signature_base/rem/view
3P/signature_base/revengerat
3P/signature_base/rknt/zip
3P/signature_base/rkntload
3P/signature_base/root/040
3P/signature_base/rootshell/php
3P/signature_base/rst/sql
3P/signature_base/ru/moonlightmaze
3P/signature_base/ru/sandworm
3P/signature_base/ru24/post
3P/signature_base/ruag
3P/signature_base/s72/shell
3P/signature_base/safe/mode
3P/signature_base/safe0ver/shell
3P/signature_base/sakula/memory
3P/signature_base/sandworm/exaramel
3P/signature_base/scanarator
3P/signature_base/scanarator/iis
3P/signature_base/scanbox
3P/signature_base/screencap
3P/signature_base/script/running
3P/signature_base/sendmail
3P/signature_base/sh/php
3P/signature_base/sh/sandworm
3P/signature_base/shankar/php
3P/signature_base/shell/php
3P/signature_base/shellbot/pl
3P/signature_base/shells/php
3P/signature_base/shelltools/g0t
3P/signature_base/shimrat
3P/signature_base/shimratreporter
3P/signature_base/sig/2008
3P/signature_base/sig/238
3P/signature_base/silence
3P/signature_base/simattacker/vrsion
3P/signature_base/simple/backdoor
3P/signature_base/simple/php
3P/signature_base/simshell/1
3P/signature_base/sincap/php
3P/signature_base/sofacy/fybis
3P/signature_base/splitjoin/v1
3P/signature_base/sql/php
3P/signature_base/sqlcheck
3P/signature_base/sqlmap
3P/signature_base/stealthwasp/s
3P/signature_base/stnc/php
3P/signature_base/streamex/shellcrew
3P/signature_base/stuxshop/config
3P/signature_base/susp/archive
3P/signature_base/susp/disable
3P/signature_base/susp/double
3P/signature_base/susp/elf
3P/signature_base/susp/expl
3P/signature_base/susp/jdniexploit
3P/signature_base/susp/netsh
3P/signature_base/susp/nk
3P/signature_base/susp/ps1
3P/signature_base/susp/ransom
3P/signature_base/susp/screenconnect
3P/signature_base/susp/shellpop
3P/signature_base/svchostdll
3P/signature_base/ta17/293a
3P/signature_base/telebots/intercepterng
3P/signature_base/telnet/cgi
3P/signature_base/telnetd/pl
3P/signature_base/thelast
3P/signature_base/tofu/backdoor
3P/signature_base/tool/asp
3P/signature_base/turla
3P/signature_base/turla/agent
3P/signature_base/ua/hermetic
3P/signature_base/unc2447/ps1
3P/signature_base/unc2447/sombrat
3P/signature_base/unc4841/esg
3P/signature_base/unc4841/seaspy
3P/signature_base/unidentified/two
3P/signature_base/unit78020
3P/signature_base/unpack/injectt
3P/signature_base/unpack/rar
3P/signature_base/user/function
3P/signature_base/vanquish
3P/signature_base/vbs/wmiexec
3P/signature_base/vssown/vbs
3P/signature_base/vubrute/config
3P/signature_base/vubrute/vubrute
3P/signature_base/vul/jquery
3P/signature_base/vuln/confluence
3P/signature_base/w/php
3P/signature_base/w3d/php
3P/signature_base/wacking/php
3P/signature_base/war/ivanti
3P/signature_base/waterbug/wipbot
3P/signature_base/wce/in
3P/signature_base/wce/modified
3P/signature_base/webshell
3P/signature_base/webshell/000
3P/signature_base/webshell/2008
3P/signature_base/webshell/ajax
3P/signature_base/webshell/ak
3P/signature_base/webshell/and
3P/signature_base/webshell/asp
3P/signature_base/webshell/aspx
3P/signature_base/webshell/ayyildiz
3P/signature_base/webshell/azrailphp
3P/signature_base/webshell/b374k
3P/signature_base/webshell/b374kphp
3P/signature_base/webshell/backupsql
3P/signature_base/webshell/browser
3P/signature_base/webshell/bypass
3P/signature_base/webshell/c99
3P/signature_base/webshell/caidao
3P/signature_base/webshell/casus
3P/signature_base/webshell/cgitelnet
3P/signature_base/webshell/cihshell
3P/signature_base/webshell/cmdasp
3P/signature_base/webshell/crystalshell
3P/signature_base/webshell/dc3
3P/signature_base/webshell/dev
3P/signature_base/webshell/dive
3P/signature_base/webshell/dtool
3P/signature_base/webshell/dx
3P/signature_base/webshell/expdoor
3P/signature_base/webshell/findsock
3P/signature_base/webshell/gamma
3P/signature_base/webshell/getpostphp
3P/signature_base/webshell/gfs
3P/signature_base/webshell/ghost
3P/signature_base/webshell/go
3P/signature_base/webshell/h4ntu
3P/signature_base/webshell/hiddens
3P/signature_base/webshell/imhapftp
3P/signature_base/webshell/ironshell
3P/signature_base/webshell/itsec
3P/signature_base/webshell/java
3P/signature_base/webshell/jsp
3P/signature_base/webshell/lamashell
3P/signature_base/webshell/liz0zim
3P/signature_base/webshell/mysql
3P/signature_base/webshell/ncc
3P/signature_base/webshell/nix
3P/signature_base/webshell/ntdaddy
3P/signature_base/webshell/pas
3P/signature_base/webshell/php
3P/signature_base/webshell/phpkit
3P/signature_base/webshell/phpspy
3P/signature_base/webshell/proxyshell
3P/signature_base/webshell/qsd
3P/signature_base/webshell/r57shell127
3P/signature_base/webshell/reader
3P/signature_base/webshell/ru24
3P/signature_base/webshell/server
3P/signature_base/webshell/sig
3P/signature_base/webshell/simattacker
3P/signature_base/webshell/simple
3P/signature_base/webshell/sincap
3P/signature_base/webshell/web
3P/signature_base/webshell/webshell
3P/signature_base/webshell/webshells
3P/signature_base/webshell/winx
3P/signature_base/webshell/wsb
3P/signature_base/webshell/z
3P/signature_base/webshell/zehir4
3P/signature_base/wh/bindshell
3P/signature_base/wiltedtulip/powershell
3P/signature_base/wiltedtulip/reflectiveloader
3P/signature_base/wiltedtulip/windows
3P/signature_base/wiltedtulip/windowstask
3P/signature_base/win/privesc
3P/signature_base/win32/adupib
3P/signature_base/windosshell/s1
3P/signature_base/windowscredentialeditor
3P/signature_base/windowsshell
3P/signature_base/windowsshell/gen
3P/signature_base/windowsshell/s3
3P/signature_base/wineggdropshellfinal/zip
3P/signature_base/winnti/nlaifsvc
3P/signature_base/winx/shell
3P/signature_base/wmimplant
3P/signature_base/woolengoldfish
3P/signature_base/woolengoldfish/sample
3P/signature_base/xssshell
3P/signature_base/xssshell/save
3P/signature_base/ysoserial/payload
3P/signature_base/zacosmall/php
3P/signature_base/zxshell
3P/signature_base/zxshell2/0
3P/telekom/security/cn/utf8
3P/telekom/security/win/iceid
3P/telekom/security/win/systembc
3P/trellix/arc/backdoorfckg
3P/trellix/arc/crime/ransomware
3P/trellix/arc/kraken/cryptor
3P/trellix/arc/miner/monero
3P/trellix/arc/ransom/hellokitty
3P/trellix/arc/ransom/mountlocker
3P/trellix/arc/stealer/emirates
3P/trellix/arc/vpnfilter
3P/volexity/any/pupyrat
3P/volexity/apk/badbazaar/common
3P/volexity/apk/badbazaar/stage2
3P/volexity/backwash/iis/scout
3P/volexity/cf/office/win
3P/volexity/charmingcypress/openvpn/configuration
3P/volexity/delivery/web/js
3P/volexity/delivery/win/charming
3P/volexity/general/php/call
3P/volexity/gimmick
3P/volexity/golang/pantegana
3P/volexity/hacktool/golang/reversessh
3P/volexity/hacktool/py/pysoxy
3P/volexity/js/sharpext
3P/volexity/ps1/powerless
3P/volexity/ps1/powerstar
3P/volexity/py/upstyle
3P/volexity/rb/rokrat/loader
3P/volexity/susp/any/jarischf
3P/volexity/vbs/basicstar
3P/volexity/vpnclient/cc
3P/volexity/web/js/xeskimmer
3P/volexity/webshell/aspx/regeorg
3P/volexity/webshell/aspx/regeorgtunnel
3P/volexity/webshell/aspx/sportsball
3P/volexity/webshell/java/behinder
3P/volexity/webshell/java/realcmd
3P/volexity/webshell/jsp/general
3P/volexity/webshell/jsp/godzilla
3P/volexity/webshell/jsp/regeorg
3P/volexity/webshell/pl/complyshell
3P/volexity/win/applejeus
3P/volexity/win/applejeus/b
3P/volexity/win/applejeus/c
3P/volexity/win/backwash/iis
3P/volexity/win/bluelight
3P/volexity/win/flipflop/ldr
3P/volexity/win/freshfire
3P/volexity/win/gimmick/dotnet
3P/volexity/win/iis/shellsave
3P/volexity/win/powerstar
3P/volexity/win/powerstar/decrypt
3P/volexity/win/powerstar/lnk
3P/volexity/win/powerstar/logmessage
3P/volexity/win/powerstar/memonly
3P/volexity/win/powerstar/persistence
admin/add_apt_key
admin/logs/install
admin/logs/syslog
admin/package/install
admin/pip_install
admin/set/default/application
admin/shutdown
archives/tar/command
archives/zip
builtin/kernel_module
builtin/openssl
builtin/rsaeuro
builtin/wolfssl
cloud/aws/metadata
cloud/google/docs
cloud/google/metadata
cloud/google/storage
combo/backdoor/daemon
combo/backdoor/dbg_exec_post
combo/backdoor/iptables
combo/backdoor/net_exec
combo/backdoor/net_pidlist
combo/backdoor/net_shell
combo/backdoor/net_term
combo/backdoor/php
combo/backdoor/py_setuptools
combo/backdoor/socat
combo/backdoor/ssh
combo/backdoor/sys_cmd
combo/dropper/bash
combo/dropper/python
combo/dropper/ruby
combo/exploit/breakout
combo/exploit/overflow/shellcode
combo/locker/curl_aes_base64
combo/locker/readdir_rename_encrypt
combo/miner/argon2d_numa_self
combo/miner/hugepages_nmi_crypto
combo/net/expect_scanner
combo/net/raw_flooder
combo/net/tunnel_proxy
combo/recon/capabilities
combo/recon/docker
combo/recon/hostinfo_collector
combo/recon/nodejs
combo/recon/upload_netinfo
combo/recon/upload_sysinfo
combo/router/passwords
combo/stealer/browser
combo/stealer/cloud
combo/stealer/connect_glob_exec
combo/stealer/creds
combo/stealer/discord
combo/stealer/ditto
combo/stealer/osascript_http_zipper
combo/stealer/pam
combo/stealer/password
combo/stealer/sqlite
combo/stealer/ssh
combo/stealer/upload/keychain/zip
combo/stealer/usbmon_webproxy_zipper
combo/stealer/wallet
combo/wiper/bash
combo/wiper/crypto
combo/wiper/sensitive_logs
combo/worm/ssh
compression/bzip2
compression/gzip
compression/xz
compression/zstd
crypto/aes
crypto/ecdsa
crypto/ed25519
crypto/fernet
crypto/file/encrypter
crypto/gost89
crypto/mining/cryptonight
crypto/mining/monero/pool
crypto/mining/nicehash_pool
crypto/mining/xmrig
crypto/openssl/user
crypto/tls
data/embedded/base64/gzip
data/embedded/base64/terms
data/embedded/base64/url
data/embedded/base64/zip
data/embedded/html
data/embedded/pem/certificate
data/embedded/pem/private_key
data/embedded/pem/test_key
data/embedded/pgp/key
data/embedded/ssh/signature
data/embedded/zstd
data/emdedded/app/manifest
databases/leveldb
databases/mysql
databases/postgresql
databases/sqlite
device/disk/info
device/pseudo_terminal
device/webcam
dylib/address/check
dylib/iterate
dylib/symbol/address
encoding/base64
encoding/csv
encoding/json
encoding/json/decode
encoding/json/encode
entitlements/iokit
env/DYLD_LIBRARY_PATH
env/HOME
env/LANG
env/LD_DEBUG
env/LD_LIBRARY_PATH
env/LD_PROFILE
env/SHELL
env/TEMP
env/TERM
env/TMPDIR
env/USER
env/get
evasion/amsi_bypass
evasion/base64/decode
evasion/base64/eval
evasion/base64/http
evasion/base64/python
evasion/bash_tcp
evasion/content/length/0
evasion/fake/library
evasion/fake/process/name
evasion/fake/ssh_user_agent
evasion/fake/updater
evasion/mask_exceptions
evasion/packer/shc
evasion/powershell_encoded
evasion/powershell_hidden
evasion/process/check
evasion/process/hide
evasion/readdir/interceptor
evasion/rename_system_binary
evasion/rootkit
evasion/squiblydoo
evasion/xor/url
exec/pipe
exec/program
exec/program/background
exfil/discord
exfil/sysinfo_http
exfil/telegram
fd/epoll
fs/backup/deletion
fs/blkid
fs/directory/create
fs/directory/list
fs/directory/remove
fs/directory/traverse
fs/event/monitoring
fs/fifo/create
fs/file/capabilities/set
fs/file/delete
fs/file/delete/forcibly
fs/file/flags/change
fs/file/make_executable
fs/file/open/by_handle
fs/file/permissions/setuid
fs/file/read
fs/file/times/set
fs/file/truncate
fs/inode/flags
fs/link/create
fs/link/read
fs/lock/update
fs/loopback
fs/mount
fs/mounts/read
fs/node/create
fs/path/from/cookie
fs/permission/chown
fs/permission/get
fs/permission/modify
fs/quota/manipulate
fs/swap/off
fs/swap/on
fs/symlink/resolve
fs/tempdir
fs/tempdir/create
fs/tempfile/create
fs/unmount
fs/watch
group/lookup
hash/blake2b
hash/md5
hash/sha1
hash/sha256
hash/whirlpool
kernel/acct
kernel/apparmor
kernel/cpu/info
kernel/dev/block/device
kernel/dev/loopback
kernel/dev/mapper
kernel/dev/mem
kernel/dev/ubi
kernel/dispatch/semaphore
kernel/hardware/info
kernel/hardware/locality
kernel/hostname/get
kernel/hostname/set
kernel/iokit/registry
kernel/kcore
kernel/key/management
kernel/kprobe
kernel/machine_id
kernel/module
kernel/module/load
kernel/netlink
kernel/opencl
kernel/perfmon
kernel/ptrace
kernel/reboot
kernel/seccomp
kernel/sysctl/nmi_watchdog
kernel/sysctl/vm.nr_hugepages
kernel/sysinfo
kernel/uname/get
malware/family/avasa/zombie
malware/family/skuld
malware/family/stealthworker
malware/family/vshell
management/esxcli
mem/anonymous/file
net/asn
net/bpf
net/ddos
net/dns
net/dns/over/https
net/dns/reverse
net/dns/txt
net/encrypted/stream
net/fetch
net/fetch/insecure
net/fetch/suspicious
net/ftp
net/geoip
net/grpc
net/hostname/resolve
net/hostport/parse
net/http/accept/encoding
net/http/auth
net/http/cookies
net/http/form/upload
net/http/post
net/http/request
net/http/server
net/http2
net/http_proxy
net/i2p
net/icmp
net/interface/get
net/interface/list
net/ip
net/ip/multicast/send
net/ip/parse
net/ip/resolve
net/ip/send/unicast
net/ip/string
net/ipp/request
net/irc
net/listen/free_port
net/mac/address
net/multiplexing
net/ntlm
net/oauth2
net/proxy_server
net/public_ip
net/raw_sockets
net/reuseport
net/sendfile
net/socket/connect
net/socket/listen
net/socket/local/address
net/socket/peer/address
net/socket/receive
net/socket/send
net/socket_filter
net/socks5
net/ssh
net/stat
net/sunrpc
net/syncookie
net/tunnel
net/udp/receive
net/udp/send
net/upload
net/url
net/url/encode
net/url/request
net/wireless
persist/launch/agent
php/wordpress/pre_term_name
privesc/rootshell
privesc/uac_bypass
process/chdir
process/chdir/unusual
process/chroot
process/create
process/detach_daemonize
process/find
process/groupid/set
process/list
process/multiprocess
process/multithreaded
process/name/set
process/namespace/set
process/parent_pid/get
process/root/check
process/thread_local_storage
process/unshare
process/userid/set
process/username/get
process/username/set
procfs/1/cgroup
procfs/arbitrary/pid
procfs/cpuinfo
procfs/meminfo
procfs/mounts
procfs/net/dev
procfs/net_route
procfs/nvidia_gpu
procfs/pid/cmdline
procfs/pid/exe
procfs/pid/maps
procfs/pid/statistics
procfs/pid/status
procfs/self/cmdline
procfs/self/exe
procfs/self/mountinfo
procfs/self/status
procfs/stat
random/insecure
ref/daemon
ref/email
ref/extensions/office
ref/ip/dns_resolver
ref/path/bin/su
ref/path/boot
ref/path/browser_extensions
ref/path/dev/mqueue
ref/path/dev/shm
ref/path/etc
ref/path/etc/hosts
ref/path/etc/ld.so.preload
ref/path/etc/resolv.conf
ref/path/hidden
ref/path/home/config
ref/path/home_library
ref/path/lib/dynamic
ref/path/tmp
ref/path/usr/bin
ref/path/usr/local
ref/path/usr/sbin
ref/path/var
ref/path/var/log
ref/path/var/tmp
ref/program/dirbuster
ref/program/gnome/keyring/daemon
ref/program/hashcat
ref/program/linpeas
ref/program/masscan
ref/program/mdworker
ref/program/metasploit
ref/program/minecraft
ref/program/nmap
ref/program/osascript
ref/program/readelf
ref/program/sshd
ref/program/sudo
ref/site/download
ref/site/github_api
ref/site/github_raw
ref/site/http/dynamic
ref/site/interface_testing
ref/site/proxy
ref/site/upload
ref/site/url/unusual
ref/site/wordpress_xmlrpc
ref/words/backdoor
ref/words/c2
ref/words/collection
ref/words/ddos
ref/words/decryptor
ref/words/dropper
ref/words/exfil
ref/words/infected
ref/words/intercept
ref/words/known_exploits
ref/words/locked/files
ref/words/obfuscate
ref/words/password
ref/words/password_finder
ref/words/payload_url
ref/words/random_target
ref/words/ransomware/conti
ref/words/ransomware/lvt
ref/words/rootkit
ref/words/server_address
ref/words/target_ip
ref/words/trojan
secrets/aws
secrets/bash_history
secrets/chrome_cookies
secrets/chromium_master_password
secrets/cookies
secrets/dot_env
secrets/firefox/master_password
secrets/gcloud
secrets/gshadow
secrets/htpasswd
secrets/keychain
secrets/keychain/unlock
secrets/keychain/write
secrets/private_key
secrets/slack
secrets/ssh
secrets/ssh_authorized_hosts
secrets/sshd/memory/map
secrets/ssl/private
security_controls/linux/iptables
security_controls/linux/iptables_delete
security_controls/linux/selinux
security_controls/linux/selinux_disable
security_controls/linux/ufw
service/systemd
shell/arbitrary_command/dev_null
shell/busybox/exec
shell/byte_offsets
shell/exec
shell/ignore_output
shell/nohup
shell/pipe_sh
shell/pipe_to_background
shell/reverse
shell/tmp_semicolon
sync/semaphore/user
systemd/out_of_dependency_tree
techniques/brute_force
time/clock/set
time/tzinfo
tools/backdoor/diamorphine
tools/backdoor/havoc
tools/backdoor/merlin
tools/backdoor/silver
tools/busybox
tools/credentials/mimikatz
tools/net/chisel
tools/net/nmap
tools/net/venom
tools/pua/backtrack
tools/recon/pspy
tools/vulncheck/metasploit
tty/getpass
tty/open
tty/parameters/get
tty/pathname
tty/vhangup
ui/alert
ui/clipboard
ui/dock/hide
ui/x11/auth
```

`make test` passes with these changes.