### PR TITLE
Add initial language-based rules to ignore F-strings and comments

### DIFF
--- a/rules/language/python.yara
+++ b/rules/language/python.yara
@@ -1,0 +1,20 @@
+rule ignore_f_string {
+	meta:
+		description = "detect f-string usage and ignore"
+	strings:
+		$fstring_single = /f'\s*\w{1,32}/
+		$fstring_double = /f"\s*\w{1,32}/
+		$fstring_triple_single = /f'''\s*\w{1,32}/
+		$fstring_triple_double = /f"""\s*\w{1,32}/
+	condition:
+		none of them
+}
+
+rule ignore_comment {
+	meta:
+		description = "detect comments up to PEP8's limit and ignore"
+	strings:
+		$comment = /\s*#[^\n]{0,79}/
+	condition:
+		none of them
+}

--- a/rules/techniques/code_eval.yara
+++ b/rules/techniques/code_eval.yara
@@ -1,3 +1,5 @@
+include "rules/language/python.yara"
+
 rule eval : notable {
 	meta:
 		description = "evaluate code dynamically using eval()"
@@ -5,7 +7,7 @@ rule eval : notable {
 		$val = /eval\([a-z\"\'\(\,\)]{1,32}/ fullword
 		$not_empty = "eval()"
 	condition:
-		$val and none of ($not*)
+		$val and none of ($not*) and ignore_f_string
 }
 
 rule python_exec : notable {
@@ -15,7 +17,7 @@ rule python_exec : notable {
 		$val = /exec\([a-z\"\'\(\,\)]{1,32}/ fullword
 		$empty = "exec()"
 	condition:
-		$val and not $empty
+		$val and not $empty and ignore_f_string
 }
 
 rule shell_eval : notable {


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/93

This PR makes an attempt to ignore rule matches made inside of both Python F-strings and comments by using YARA's `include` directive. This pattern will allow for common rules to be stored separately and then used where necessary.

TBD if this approach will cover all edge-cases but there's always the pre-processor route mentioned in the Issue.

Using the new rules:
```
❯ go run . ~/Downloads/utilpep613.py
/Users/egibs/Downloads/utilpep613.py [✅ LOW]
----------------------------------------------------------------------
RISK  KEY               DESCRIPTION                     EVIDENCE
----------------------------------------------------------------------
LOW   ref/path/usr/bin  path reference within /usr/bin  /usr/bin/env
----------------------------------------------------------------------
```

Without the new rules (which was called out in the Issue):
```
❯ go run . ~/Downloads/utilpep613.py
/Users/egibs/Downloads/utilpep613.py [⚠️ MEDIUM]
----------------------------------------------------------------------------------
RISK  KEY                   DESCRIPTION                             EVIDENCE
----------------------------------------------------------------------------------
LOW   ref/path/usr/bin      path reference within /usr/bin          /usr/bin/env
MED   techniques/code_eval  evaluate code dynamically using exec()  exec("type
----------------------------------------------------------------------------------
```