### PR TITLE
Add Makefile targets to automate Yara installations from source

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -35,12 +35,7 @@ jobs:
 
       - name: install libyara-dev
         run: |
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-updates main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-backports main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://security.ubuntu.com/ubuntu mantic-security main restricted universe multiverse"
-
-          sudo apt update && sudo apt install libyara-dev -y
+          make build-yara
 
       - name: Test
         run: |

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -60,12 +60,7 @@ jobs:
 
       - name: install libyara-dev
         run: |
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-updates main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://archive.ubuntu.com/ubuntu/ mantic-backports main restricted universe multiverse"
-          sudo add-apt-repository -n -y "deb http://security.ubuntu.com/ubuntu mantic-security main restricted universe multiverse"
-
-          sudo apt update && sudo apt install libyara-dev -y
+          make build-yara
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@82d40c283aeb1f2b6595839195e95c2d6a49081b # v3.7.1

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ yara-reqs:
 		elif [ "$(LINT_DISTRO)" = "fedora" ] || [ "$(LINT_DISTRO)" = "rocky" ]; then \
 			sudo dnf -y update && sudo dnf install -y automake bison flex gcc libtool make openssl-devel pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "alpine" ]; then \
-			sudo apk update && sudo apk add autoconf automake bison build-base flex gcc libtool linux-headers make openssl-dev pkgconf; \
+			sudo apk update && sudo apk add autoconf automake bison build-base flex gcc libtool linux-headers make openssl-dev pkgconf-dev; \
 		elif [ "$(LINT_DISTRO)" = "wolfi" ]; then \
 			apk update && apk add autoconf automake bison build-base curl flex gcc libtool linux-headers make openssl-dev pkgconf-dev sudo; \
 		elif [ "$(LINT_DISTRO)" = "arch" ] || [ "$(LINT_DISTRO)" = "archarm" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -90,8 +90,10 @@ yara-reqs:
 			sudo pacman -Syu --noconfirm autoconf automake bison flex gcc libtool make openssl pkgconf; \
 			sudo mkdir -p /etc/ld.so.conf.d; \
 			echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/local.conf; \
-		elif [ "$(LINT_DISTRO)" = "opensuse" ] || [ "$(LINT_DISTRO)" = "opensuse-leap" ]; then \
-			sudo zypper refresh && sudo zypper install -y autoconf automake bison flex gcc libopenssl-devel libtool make pkg-config; \
+		elif [ "$(LINT_DISTRO)" = "opensuse-leap" ] || [ "$(LINT_DISTRO)" = "opensuse-tumbleweed" ]; then \
+			sudo zypper refresh && sudo zypper install -y autoconf automake awk bison flex gcc gzip libopenssl-devel libtool make pkg-config; \
+			sudo mkdir -p /etc/ld.so.conf.d; \
+			echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/local.conf; \
 		else \
 			echo "Unsupported Linux distribution: $(LINT_DISTRO)"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -77,15 +77,15 @@ yara-reqs:
 		brew install automake bison flex gcc libtool m4 make pkg-config; \
 	elif [ "$(LINT_OS_LOWER)" = "linux" ]; then \
 		if [ "$(LINT_DISTRO)" = "ubuntu" ] || [ "$(LINT_DISTRO)" = "debian" ]; then \
-			sudo apt-get update && sudo apt-get install -y automake bison flex gcc libtool make pkg-config; \
+			sudo apt-get update && sudo apt-get install -y automake bison flex gcc libtool libssl-dev make pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "centos" ] || [ "$(LINT_DISTRO)" = "redhat" ]; then \
-			sudo yum -y update && sudo yum install -y automake bison flex gcc libtool make pkg-config; \
+			sudo yum -y update && sudo yum install -y automake bison flex gcc libtool make openssl-devel pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "fedora" ] || [ "$(LINT_DISTRO)" = "rocky" ]; then \
-			sudo dnf -y update && sudo dnf install -y automake bison flex gcc libtool make pkg-config; \
+			sudo dnf -y update && sudo dnf install -y automake bison flex gcc libtool make openssl-devel pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "alpine" ]; then \
-			sudo apk update && sudo apk add autoconf automake bison build-base flex gcc libtool linux-headers make pkgconf; \
+			sudo apk update && sudo apk add autoconf automake bison build-base flex gcc libtool linux-headers make openssl-dev pkgconf; \
 		elif [ "$(LINT_DISTRO)" = "wolfi" ]; then \
-			apk update && apk add autoconf automake bison build-base curl flex gcc libtool linux-headers make pkgconf-dev sudo; \
+			apk update && apk add autoconf automake bison build-base curl flex gcc libtool linux-headers make openssl-dev pkgconf-dev sudo; \
 		else \
 			echo "Unsupported Linux distribution: $(LINT_DISTRO)"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,8 @@ yara-reqs:
 	@if [ "$(LINT_OS_LOWER)" = "darwin" ]; then \
 		brew install automake bison flex gcc libtool m4 make pkg-config; \
 	elif [ "$(LINT_OS_LOWER)" = "linux" ]; then \
-		if [ "$(LINT_DISTRO)" = "ubuntu" ] || [ "$(LINT_DISTRO)" = "debian" ]; then \
-			sudo apt-get update && sudo apt-get install -y automake bison flex gcc libtool libssl-dev make pkg-config; \
+		if [ "$(LINT_DISTRO)" = "ubuntu" ] || [ "$(LINT_DISTRO)" = "debian" ] || [ "$(LINT_DISTRO)" = "kali" ]; then \
+			sudo apt-get -y update && sudo apt-get install -y automake bison flex gcc libtool libssl-dev make pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "centos" ] || [ "$(LINT_DISTRO)" = "redhat" ]; then \
 			sudo yum -y update && sudo yum install -y automake bison flex gcc libtool make openssl-devel pkg-config; \
 		elif [ "$(LINT_DISTRO)" = "fedora" ] || [ "$(LINT_DISTRO)" = "rocky" ]; then \
@@ -86,6 +86,10 @@ yara-reqs:
 			sudo apk update && sudo apk add autoconf automake bison build-base flex gcc libtool linux-headers make openssl-dev pkgconf; \
 		elif [ "$(LINT_DISTRO)" = "wolfi" ]; then \
 			apk update && apk add autoconf automake bison build-base curl flex gcc libtool linux-headers make openssl-dev pkgconf-dev sudo; \
+		elif [ "$(LINT_DISTRO)" = "arch" ] || [ "$(LINT_DISTRO)" = "archarm" ]; then \
+			sudo pacman -Syu --noconfirm autoconf automake bison flex gcc libtool make openssl pkgconf; \
+			sudo mkdir -p /etc/ld.so.conf.d; \
+			echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/local.conf; \
 		else \
 			echo "Unsupported Linux distribution: $(LINT_DISTRO)"; \
 		fi; \

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,8 @@ yara-reqs:
 			sudo pacman -Syu --noconfirm autoconf automake bison flex gcc libtool make openssl pkgconf; \
 			sudo mkdir -p /etc/ld.so.conf.d; \
 			echo "/usr/local/lib" | sudo tee /etc/ld.so.conf.d/local.conf; \
+		elif [ "$(LINT_DISTRO)" = "opensuse" ] || [ "$(LINT_DISTRO)" = "opensuse-leap" ]; then \
+			sudo zypper refresh && sudo zypper install -y autoconf automake bison flex gcc libopenssl-devel libtool make pkg-config; \
 		else \
 			echo "Unsupported Linux distribution: $(LINT_DISTRO)"; \
 		fi; \

--- a/README.md
+++ b/README.md
@@ -196,6 +196,8 @@ This has been tested on the following Platforms:
 - Kali
 - macOS
 - OpenSUSE
+    - Leap
+    - Tumbleweed
 - Rocky
 - Wolfi
 

--- a/README.md
+++ b/README.md
@@ -183,11 +183,18 @@ You'll need to install the `yara` C library:
 brew install yara || sudo apt install libyara-devel || sudo dnf install yara-devel || sudo pacman -S yara
 ```
 
-Additionally, ensure that Yara's version is `4.3.2`. 
+If you wish to install a known, working version of Yara from source, run the following Makefile target:
+```
+make build-yara
+```
 
-If this version is not available via package managers, manually download the release from [here](https://github.com/VirusTotal/yara/releases) and build it from source by following [these](https://yara.readthedocs.io/en/latest/gettingstarted.html#compiling-and-installing-yara) steps.
-
-Once Yara is installed, run `sudo ldconfig -v` to ensure that the library is loaded.
+This has been tested on the following Platforms:
+- Alpine
+- CentOS
+- Fedora
+- macOS
+- Rocky
+- Wolfi
 
 #### MacOS: `bincapz` will damage your computer
 

--- a/README.md
+++ b/README.md
@@ -217,13 +217,13 @@ OpenSSL's libraries are required for Yara (depending on the platform being used)
 
 A non-exhaustive list of Linux distributions and their respectie package names can be found below:
 
-* Debian, Ubuntu
-  * `libssl-dev`
-* CentOS, Fedora, RHEL, Rocky:
-  * `openssl-devel`
 * Alpine/Wolfi:
   * `openssl-dev`
 * Arch:
   * `openssl` (Arch includes the libraries)
+* CentOS, Fedora, RHEL, Rocky:
+  * `openssl-devel`
+* Debian, Ubuntu
+  * `libssl-dev`
 * OpenSUSE:
   * `libopenssl-devel`

--- a/README.md
+++ b/README.md
@@ -195,6 +195,7 @@ This has been tested on the following Platforms:
 - Fedora
 - Kali
 - macOS
+- OpenSUSE
 - Rocky
 - Wolfi
 

--- a/README.md
+++ b/README.md
@@ -210,3 +210,20 @@ In order to compile the rules from this project there are a couple of options:
 2. Run a Linux container or VM of choice and install `bincapz` and its dependencies
 
 Disabling macOS' System Integrity Protection via `csrutil` to run `bincapz` with `--third-party` is *not* recommended.
+
+#### `yara addfile third_party/yara-rules-full.yar: invalid field name "imphash"`
+
+OpenSSL's libraries are required for Yara (depending on the platform being used).
+
+A non-exhaustive list of Linux distributions and their respectie package names can be found below:
+
+* Debian, Ubuntu
+  * `libssl-dev`
+* CentOS, Fedora, RHEL, Rocky:
+  * `openssl-devel`
+* Alpine/Wolfi:
+  * `openssl-dev`
+* Arch:
+  * `openssl` (Arch includes the libraries)
+* OpenSUSE:
+  * `libopenssl-devel`

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ This has been tested on the following Platforms:
 - Rocky
 - Wolfi
 
+For other distributions, consult the distribution's package manager to install the equivalent packages outlined [here](https://yara.readthedocs.io/en/latest/gettingstarted.html).
+
 #### MacOS: `bincapz` will damage your computer
 
 The Rules from https://github.com/mthcht/ThreatHunting-Keywords-yara-rules will set off macOS' malware protections.

--- a/README.md
+++ b/README.md
@@ -190,8 +190,10 @@ make build-yara
 
 This has been tested on the following Platforms:
 - Alpine
+- Arch
 - CentOS
 - Fedora
+- Kali
 - macOS
 - Rocky
 - Wolfi


### PR DESCRIPTION
The `README` mentions that Yara can be installed from source but it would be nicer if there was automation to handle those steps.

This PR adds two Makefile targets (required packages; actual building and installing, respectively) to automatically build Yara from source for a known version (`4.3.2` but we can make this `4.5.0` if that's preferred).

I tested this on all of the platforms mentioned in the updated `README` (except for macOS which was done natively). Additionally, this should close https://github.com/chainguard-dev/bincapz/issues/63 due to the installation of OpenSSL dev packages where appropriate.

Example using Wolfi:
```
❯ docker run --rm -it -v $(pwd):/bincapz -w /bincapz cgr.dev/chainguard/wolfi-base
d39eec8edfb3:/bincapz# apk update
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 54673 distinct packages available
d39eec8edfb3:/bincapz# apk add make
(1/1) Installing make (4.4.1-r2)
OK: 15 MiB in 16 packages
d39eec8edfb3:/bincapz# make build-yara
fetch https://packages.wolfi.dev/os/aarch64/APKINDEX.tar.gz
 [https://packages.wolfi.dev/os]
OK: 54673 distinct packages available
(1/39) Installing m4 (1.4.19-r4)
(2/39) Installing libbz2-1 (1.0.8-r6)
(3/39) Installing perl (5.38.2-r1)
(4/39) Installing autoconf (2.72-r0)
(5/39) Installing automake (1.16.5-r2)
(6/39) Installing bison (3.8.2-r3)
(7/39) Installing libgcc (13.2.0-r6)
(8/39) Installing libstdc++ (13.2.0-r6)
(9/39) Installing binutils (2.42-r1)
(10/39) Installing libstdc++-dev (13.2.0-r6)
(11/39) Installing posix-cc-wrappers (1-r2)
(12/39) Installing libatomic (13.2.0-r6)
(13/39) Installing gmp (6.3.0-r1)
(14/39) Installing libgo (13.2.0-r6)
(15/39) Installing libgomp (13.2.0-r6)
(16/39) Installing isl (0.26-r2)
(17/39) Installing mpfr (4.2.1-r2)
(18/39) Installing mpc (1.3.1-r2)
(19/39) Installing gcc (13.2.0-r6)
(20/39) Installing libxcrypt-dev (4.4.36-r4)
(21/39) Installing linux-headers (6.6.29-r0)
(22/39) Installing nss-db (2.39-r3)
(23/39) Installing nss-hesiod (2.39-r3)
(24/39) Installing glibc-dev (2.39-r3)
(25/39) Installing pkgconf (2.2.0-r1)
(26/39) Installing build-base (1-r7)
(27/39) Installing libbrotlicommon1 (1.1.0-r1)
(28/39) Installing libbrotlidec1 (1.1.0-r1)
(29/39) Installing libnghttp2-14 (1.61.0-r1)
(30/39) Installing libunistring (1.2-r1)
(31/39) Installing libidn2 (2.3.7-r1)
(32/39) Installing libpsl (0.21.5-r1)
(33/39) Installing libcurl-openssl4 (8.7.1-r2)
(34/39) Installing curl (8.7.1-r2)
(35/39) Installing flex (2.6.4-r5)
(36/39) Installing libltdl (2.4.7-r3)
(37/39) Installing libtool (2.4.7-r3)
(38/39) Installing pkgconf-dev (2.2.0-r1)
(39/39) Installing sudo (1.9.15_p5-r0)
OK: 524 MiB in 55 packages
libtoolize: putting auxiliary files in AC_CONFIG_AUX_DIR, 'build-aux'.
libtoolize: copying file 'build-aux/ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'.
libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
configure.ac:23: warning: The macro 'AC_PROG_CC_C99' is obsolete.
configure.ac:23: You should run autoupdate.
./lib/autoconf/c.m4:1662: AC_PROG_CC_C99 is expanded from...
configure.ac:23: the top level
configure.ac:25: warning: AC_PROG_LEX without either yywrap or noyywrap is obsolete
./lib/autoconf/programs.m4:743: _AC_PROG_LEX is expanded from...
./lib/autoconf/programs.m4:736: AC_PROG_LEX is expanded from...
aclocal.m4:1072: AM_PROG_LEX is expanded from...
configure.ac:25: the top level
configure.ac:93: warning: The macro 'AC_LANG_C' is obsolete.
configure.ac:93: You should run autoupdate.
./lib/autoconf/c.m4:72: AC_LANG_C is expanded from...
m4/acx_pthread.m4:63: ACX_PTHREAD is expanded from...
configure.ac:93: the top level
configure.ac:93: warning: The macro 'AC_TRY_LINK' is obsolete.
configure.ac:93: You should run autoupdate.
./lib/autoconf/general.m4:2918: AC_TRY_LINK is expanded from...
m4/acx_pthread.m4:63: ACX_PTHREAD is expanded from...
configure.ac:93: the top level
configure.ac:394: warning: AC_C_BIGENDIAN should be used with AC_CONFIG_HEADERS
configure.ac:20: installing 'build-aux/ar-lib'
configure.ac:20: installing 'build-aux/compile'
configure.ac:38: installing 'build-aux/config.guess'
configure.ac:38: installing 'build-aux/config.sub'
configure.ac:8: installing 'build-aux/install-sh'
configure.ac:8: installing 'build-aux/missing'
Makefile.am: installing 'build-aux/depcomp'
configure.ac: installing 'build-aux/ylwrap'
parallel-tests: installing 'build-aux/test-driver'
checking whether make supports nested variables... yes
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a race-free mkdir -p... /bin/mkdir -p
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking whether make sets $(MAKE)... yes
checking whether make supports the include directive... yes (GNU style)
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables...
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether the compiler supports GNU C... yes
checking whether gcc accepts -g... yes
checking for gcc option to enable C11 features... none needed
checking whether gcc understands -c and -o together... yes
checking dependency style of gcc... gcc3
checking for ar... ar
checking the archiver (ar) interface... ar
checking for gcc... (cached) gcc
checking whether the compiler supports GNU C... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to enable C11 features... (cached) none needed
checking whether gcc understands -c and -o together... (cached) yes
checking dependency style of gcc... (cached) gcc3
checking for flex... flex
checking for lex output file root... lex.yy
checking for lex library... none needed
checking for library containing yywrap... no
checking whether yytext is a pointer... yes
checking for bison... bison -y
checking for inline... inline
checking for stdio.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for strings.h... yes
checking for sys/stat.h... yes
checking for sys/types.h... yes
checking for unistd.h... yes
checking whether byte ordering is bigendian... no
checking for gcc option to enable large file support... none needed
checking build system type... aarch64-unknown-linux-gnu
checking host system type... aarch64-unknown-linux-gnu
checking how to print strings... printf
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by gcc... /usr/aarch64-unknown-linux-gnu/bin/ld
checking if the linker (/usr/aarch64-unknown-linux-gnu/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 32768
checking how to convert aarch64-unknown-linux-gnu file names to aarch64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert aarch64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/aarch64-unknown-linux-gnu/bin/ld option to reload object files... -r
checking for file... no
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for a working dd... /bin/dd
checking how to truncate binary pipes... /bin/dd bs=4096 count=1
checking for mt... no
checking if : is a manifest tool... no
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/aarch64-unknown-linux-gnu/bin/ld) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for the pthreads library -lpthreads... no
checking whether pthreads work without any flags... yes
checking for joinable pthread attribute... PTHREAD_CREATE_JOINABLE
checking if more special flags are required for pthreads... no
checking whether to check for GCC pthread/shared inconsistencies... yes
checking whether -pthread is sufficient with -shared... yes
checking for isnan in -lm... yes
checking for log2 in -lm... yes
checking for strlcpy... yes
checking for strlcat... yes
checking for memmem... yes
checking for timegm... yes
checking for _mkgmtime... no
checking for clock_gettime... yes
checking for stdbool.h... yes
checking for pkg-config... /usr/bin/pkg-config
checking pkg-config is at least version 0.9.0... yes
checking for openssl/evp.h... no
checking for openssl/asn1.h... no
checking for openssl/crypto.h... no
checking for openssl/bio.h... no
checking for openssl/pkcs7.h... no
checking for openssl/x509.h... no
checking for openssl/safestack.h... no
checking for EVP_DigestInit in -lcrypto... no
checking for EVP_DigestUpdate in -lcrypto... no
checking for EVP_DigestFinal in -lcrypto... no
checking for EVP_md5 in -lcrypto... no
checking for EVP_sha1 in -lcrypto... no
checking for EVP_sha256 in -lcrypto... no
configure: WARNING:

*****************************************************************
  Could not find OpenSSL library. Some features in "pe" module
  have been disabled. If you want to enable all features please
  install OpenSSL and run this script again.
*****************************************************************

checking for Microsoft Crypto API... checking for wincrypt.h... no
checking for MacOSX Common Crypto API... checking for CommonCrypto/CommonCrypto.h... no
configure: WARNING:

*****************************************************************
  Could not find alternative APIs for hash functions. The "hash"
  module has been disabled.
*****************************************************************

checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating yara.pc
config.status: executing depfiles commands
config.status: executing libtool commands
make[1]: Entering directory '/bincapz/out/yara-4.3.2'
make  all-am
make[2]: Entering directory '/bincapz/out/yara-4.3.2'
  CC       cli/args.o
  CC       cli/common.o
  CC       cli/threading.o
  CC       cli/yara.o
  CC       libyara/modules/tests/la-tests.lo
  CC       libyara/modules/elf/la-elf.lo
  CC       libyara/modules/math/la-math.lo
  CC       libyara/modules/time/la-time.lo
  CC       libyara/modules/pe/la-pe.lo
  CC       libyara/modules/pe/la-pe_utils.lo
  CC       libyara/modules/console/la-console.lo
  CC       libyara/modules/string/la-string.lo
  CC       libyara/modules/dotnet/la-dotnet.lo
  CC       libyara/la-grammar.lo
  CC       libyara/la-ahocorasick.lo
  CC       libyara/la-arena.lo
  CC       libyara/la-atoms.lo
  CC       libyara/la-base64.lo
  CC       libyara/la-bitmask.lo
  CC       libyara/la-compiler.lo
  CC       libyara/la-endian.lo
  CC       libyara/la-exec.lo
  CC       libyara/la-exefiles.lo
  CC       libyara/la-filemap.lo
  CC       libyara/la-hash.lo
  CC       libyara/la-hex_grammar.lo
  CC       libyara/la-hex_lexer.lo
  CC       libyara/la-lexer.lo
  CC       libyara/la-libyara.lo
  CC       libyara/la-mem.lo
  CC       libyara/la-modules.lo
  CC       libyara/la-notebook.lo
  CC       libyara/la-object.lo
  CC       libyara/la-parser.lo
  CC       libyara/la-proc.lo
  CC       libyara/la-re.lo
    CC       libyara/la-re_grammar.lo
  CC       libyara/la-re_lexer.lo
  CC       libyara/la-rules.lo
  CC       libyara/la-scan.lo
  CC       libyara/la-scanner.lo
  CC       libyara/la-simple_str.lo
  CC       libyara/la-sizedstr.lo
  CC       libyara/la-stack.lo
  CC       libyara/la-stopwatch.lo
  CC       libyara/la-strutils.lo
  CC       libyara/la-stream.lo
  CC       libyara/tlshc/la-tlsh.lo
  CC       libyara/tlshc/la-tlsh_impl.lo
  CC       libyara/tlshc/la-tlsh_util.lo
  CC       libyara/la-threading.lo
  CC       libyara/proc/la-linux.lo
  CCLD     libyara.la
  CCLD     yara
  CC       cli/yarac.o
  CCLD     yarac
make[2]: Leaving directory '/bincapz/out/yara-4.3.2'
make[1]: Leaving directory '/bincapz/out/yara-4.3.2'
make  install-am
make[1]: Entering directory '/bincapz/out/yara-4.3.2'
make[2]: Entering directory '/bincapz/out/yara-4.3.2'
 /bin/mkdir -p '/usr/local/lib'
 /bin/sh ./libtool   --mode=install /usr/bin/install -c   libyara.la '/usr/local/lib'
libtool: install: /usr/bin/install -c .libs/libyara.so.10.0.0 /usr/local/lib/libyara.so.10.0.0
libtool: install: (cd /usr/local/lib && { ln -s -f libyara.so.10.0.0 libyara.so.10 || { rm -f libyara.so.10 && ln -s libyara.so.10.0.0 libyara.so.10; }; })
libtool: install: (cd /usr/local/lib && { ln -s -f libyara.so.10.0.0 libyara.so || { rm -f libyara.so && ln -s libyara.so.10.0.0 libyara.so; }; })
libtool: install: /usr/bin/install -c .libs/libyara.lai /usr/local/lib/libyara.la
libtool: install: /usr/bin/install -c .libs/libyara.a /usr/local/lib/libyara.a
libtool: install: chmod 644 /usr/local/lib/libyara.a
libtool: install: ranlib /usr/local/lib/libyara.a
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin" ldconfig -n /usr/local/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/local/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the '-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the 'LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the 'LD_RUN_PATH' environment variable
     during linking
   - use the '-Wl,-rpath -Wl,LIBDIR' linker flag
   - have your system administrator add LIBDIR to '/etc/ld.so.conf'

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
 /bin/mkdir -p '/usr/local/bin'
  /bin/sh ./libtool   --mode=install /usr/bin/install -c yara yarac '/usr/local/bin'
libtool: install: /usr/bin/install -c .libs/yara /usr/local/bin/yara
libtool: install: /usr/bin/install -c .libs/yarac /usr/local/bin/yarac
 /bin/mkdir -p '/usr/local/include'
 /usr/bin/install -c -m 644 libyara/include/yara.h '/usr/local/include'
 /bin/mkdir -p '/usr/local/share/man/man1'
 /usr/bin/install -c -m 644 'yara.man' '/usr/local/share/man/man1/yara.1'
 /usr/bin/install -c -m 644 'yarac.man' '/usr/local/share/man/man1/yarac.1'
 /bin/mkdir -p '/usr/local/lib/pkgconfig'
 /usr/bin/install -c -m 644 yara.pc '/usr/local/lib/pkgconfig'
 /bin/mkdir -p '/usr/local/include/yara'
 /usr/bin/install -c -m 644 libyara/include/yara/ahocorasick.h libyara/include/yara/arena.h libyara/include/yara/atoms.h libyara/include/yara/base64.h libyara/include/yara/bitmask.h libyara/include/yara/compiler.h libyara/include/yara/error.h libyara/include/yara/exec.h libyara/include/yara/exefiles.h libyara/include/yara/filemap.h libyara/include/yara/hash.h libyara/include/yara/integers.h libyara/include/yara/libyara.h libyara/include/yara/limits.h libyara/include/yara/mem.h libyara/include/yara/modules.h libyara/include/yara/notebook.h libyara/include/yara/object.h libyara/include/yara/parser.h libyara/include/yara/proc.h libyara/include/yara/re.h libyara/include/yara/rules.h libyara/include/yara/scan.h libyara/include/yara/scanner.h libyara/include/yara/simple_str.h libyara/include/yara/sizedstr.h libyara/include/yara/stack.h libyara/include/yara/stopwatch.h libyara/include/yara/stream.h libyara/include/yara/strutils.h libyara/include/yara/threading.h libyara/include/yara/types.h libyara/include/yara/unaligned.h libyara/include/yara/utils.h '/usr/local/include/yara'
make[2]: Leaving directory '/bincapz/out/yara-4.3.2'
make[1]: Leaving directory '/bincapz/out/yara-4.3.2'
make[1]: Entering directory '/bincapz/out/yara-4.3.2'
make  check-am
make[2]: Entering directory '/bincapz/out/yara-4.3.2'
make  test-arena test-alignment test-atoms test-api test-rules test-pe test-elf test-version test-bitmask test-math test-stack test-re-split test-async test-string test-exception   test-dotnet
make[3]: Entering directory '/bincapz/out/yara-4.3.2'
  CC       tests/test-arena.o
  CC       tests/util.o
  CCLD     test-arena
  CC       tests/test-alignment.o
  CCLD     test-alignment
  CC       tests/test-atoms.o
  CCLD     test-atoms
  CC       tests/test-api.o
  CCLD     test-api
  CC       tests/test-rules.o
  CC       tests/mapper-mapper.o
  CCLD     tests/mapper
  CCLD     test-rules
  CC       tests/test-pe.o
  CCLD     test-pe
  CC       tests/test-elf.o
  CCLD     test-elf
  CC       tests/test-version.o
  CCLD     test-version
  CC       tests/test-bitmask.o
  CCLD     test-bitmask
  CC       tests/test-math.o
  CCLD     test-math
  CC       tests/test-stack.o
  CCLD     test-stack
  CC       tests/test-re-split.o
  CCLD     test-re-split
  CC       tests/test-async.o
  CCLD     test-async
  CC       tests/test-string.o
  CCLD     test-string
  CC       tests/test-exception.o
  CCLD     test-exception
  CC       tests/test-dotnet.o
  CCLD     test-dotnet
make[3]: Leaving directory '/bincapz/out/yara-4.3.2'
make  check-TESTS
make[3]: Entering directory '/bincapz/out/yara-4.3.2'
make[4]: Entering directory '/bincapz/out/yara-4.3.2'
PASS: test-arena
PASS: test-alignment
PASS: test-atoms
PASS: test-api
PASS: test-rules
PASS: test-pe
PASS: test-elf
PASS: test-version
PASS: test-bitmask
PASS: test-math
PASS: test-stack
PASS: test-re-split
PASS: test-async
PASS: test-string
PASS: test-exception
PASS: test-dotnet
============================================================================
Testsuite summary for yara 4.3.2
============================================================================
# TOTAL: 16
# PASS:  16
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[4]: Leaving directory '/bincapz/out/yara-4.3.2'
make[3]: Leaving directory '/bincapz/out/yara-4.3.2'
make[2]: Leaving directory '/bincapz/out/yara-4.3.2'
make[1]: Leaving directory '/bincapz/out/yara-4.3.2'
ldconfig: Path `/usr/local/lib64' given more than once
(from /etc/ld.so.conf:2 and /etc/ld.so.conf:1)
ldconfig: Path `/lib64' given more than once
(from /etc/ld.so.conf:4 and /etc/ld.so.conf:3)
ldconfig: Path `/usr/lib64' given more than once
(from /etc/ld.so.conf:6 and /etc/ld.so.conf:5)
ldconfig: Path `/lib' given more than once
(from <builtin>:0 and /etc/ld.so.conf:3)
ldconfig: Path `/lib64' given more than once
(from <builtin>:0 and /etc/ld.so.conf:3)
ldconfig: Can't stat /libilp32: No such file or directory
ldconfig: Path `/usr/lib' given more than once
(from <builtin>:0 and /etc/ld.so.conf:5)
ldconfig: Path `/usr/lib64' given more than once
(from <builtin>:0 and /etc/ld.so.conf:5)
ldconfig: Can't stat /usr/libilp32: No such file or directory
/usr/local/lib: (from /etc/ld.so.conf:1)
	libyara.so.10 -> libyara.so.10.0.0
/lib: (from /etc/ld.so.conf:3)
	libpkgconf.so.5 -> libpkgconf.so.5.0.0
	libnss_hesiod.so.2 -> libnss_hesiod.so.2
	libnss_db.so.2 -> libnss_db.so.2
	libz.so.1 -> libz.so.1.3.1
	libutil.so.1 -> libutil.so.1
	libthread_db.so.1 -> libthread_db.so.1
	librt.so.1 -> librt.so.1
	libresolv.so.2 -> libresolv.so.2
	libpthread.so.0 -> libpthread.so.0
	libnss_files.so.2 -> libnss_files.so.2
	libnss_dns.so.2 -> libnss_dns.so.2
	libnss_compat.so.2 -> libnss_compat.so.2
	libnsl.so.1 -> libnsl.so.1
	libmvec.so.1 -> libmvec.so.1
	libmemusage.so -> libmemusage.so
	libm.so.6 -> libm.so.6
	libdl.so.2 -> libdl.so.2
	libc_malloc_debug.so.0 -> libc_malloc_debug.so.0
	libc.so.6 -> libc.so.6
	libapk.so.2.14.0 -> libapk.so.2.14.0
	libanl.so.1 -> libanl.so.1
	libBrokenLocale.so.1 -> libBrokenLocale.so.1
	ld-linux-aarch64.so.1 -> ld-linux-aarch64.so.1
/usr/lib: (from /etc/ld.so.conf:5)
	libltdl.so.7 -> libltdl.so.7.3.2
	libcurl.so.4 -> libcurl.so.4.8.0
	libpsl.so.5 -> libpsl.so.5.3.5
	libidn2.so.0 -> libidn2.so.0.4.0
	libunistring.so.5 -> libunistring.so.5.1.0
	libnghttp2.so.14 -> libnghttp2.so.14.28.0
	libbrotlidec.so.1 -> libbrotlidec.so.1.1.0
	libbrotlicommon.so.1 -> libbrotlicommon.so.1.1.0
	libubsan.so.1 -> libubsan.so.1.0.0
	libtsan.so.2 -> libtsan.so.2.0.0
	liblsan.so.0 -> liblsan.so.0.0.0
	libitm.so.1 -> libitm.so.1.0.0
	libhwasan.so.0 -> libhwasan.so.0.0.0
	libcc1.so.0 -> libcc1.so.0.0.0
	libasan.so.8 -> libasan.so.8.0.0
	libmpc.so.3 -> libmpc.so.3.3.1
	libmpfr.so.6 -> libmpfr.so.6.2.1
	libisl.so.23 -> libisl.so.23.3.0
	libgomp.so.1 -> libgomp.so.1.0.0
	libgo.so.22 -> libgo.so.22.0.0
	libgmpxx.so.4 -> libgmpxx.so.4.7.0
	libgmp.so.10 -> libgmp.so.10.5.0
	libatomic.so.1 -> libatomic.so.1.2.0
	libstdc++.so.6 -> libstdc++.so.6.0.32
	libgcc_s.so.1 -> libgcc_s.so.1
	libbz2.so.1 -> libbz2.so.1.0.8
	libssl.so.3 -> libssl.so.3
	libcrypto.so.3 -> libcrypto.so.3
	libcrypt.so.1 -> libcrypt.so.1.1.0
/bincapz
```