### PR TITLE
Replace ignoreSelf with include/exclude syntax for scan paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ To inspect a binary, pass it as an argument to dump a list of predicted capabili
 bincapz /bin/ping
 ```
 
+To specify path exclusions and inclusions, specify multiple paths with `/-` or `/+`:
+```
+bincapz bincapz/- samples/+
+```
+
+> In this example, all `bincapz` paths will be ignored while `samples` paths will be allowed.
+
+The `/-, /+` syntax is entirely optional and specifying multiple paths/binaries without this syntax will scan each in succession without any filtering.
+
 There are flags for controlling output (see the Usage section) and filtering out rules. Here's the `--format=markdown` output:
 | RISK | KEY | DESCRIPTION | EVIDENCE |
 |--------|-----------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -11,7 +11,8 @@ import (
 )
 
 type Config struct {
-	IgnoreSelf       bool
+	ExcludePaths     []string
+	IncludePaths     []string
 	IgnoreTags       []string
 	IncludeDataFiles bool
 	MinFileScore     int


### PR DESCRIPTION
This is an iteration on https://github.com/chainguard-dev/bincapz/pull/187 which will close #184.

I'll leave this as a draft and gather feedback; the gist of it is to allow scan paths to be excluded while also providing control over specific sub-paths that may need to be scanned within said path. The easiest, most passive way to do this was to support `/-` and `/+` suffixes on the provided scan paths.

This functionality can be useful in cases where a directory contains many files that aren't of material concern with the exception of a handful of directories. This syntax will also allow for more directories to be ignored while allowing a common directory shared between them.

The easiest example of this can be seen in the aforementioned PR -- filter everything in the `bincapz` directory while allowing the `samples` directory to be scanned. However, other directories could be included.

Example:
```
❯ go run . --verbose bincapz/-
time=2024-05-05T20:04:31.459-05:00 level=INFO source=/Users/egibs/repos/bincapz/bincapz.go:55 msg="bincapz starting"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=evasion/binary-opaque.yara warning="string \"$word_with_spaces\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=ref/email.yara warning="string \"$e_re\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=ref/ip.yara warning="string \"$ipv4\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=ref/ip_port.yara warning="string \"$ipv4\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=shell/background-sleep.yara warning="string \"$cmd_bg\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=systemd/no_docs_or_comments.yara warning="string \"$ex_comment\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=third_party/mthcht_thk_yara_rules.yar warning="string \"$string22_DynastyPersist_offensive_tool_keyword\" may slow down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=third_party/mthcht_thk_yara_rules.yar warning="rule is slowing down scanning"
time=2024-05-05T20:04:32.630-05:00 level=WARN source=/Users/egibs/repos/bincapz/pkg/rules/rules.go:70 msg=warning namespace=third_party/mthcht_thk_yara_rules.yar warning="string \"$string7_RDPassSpray_offensive_tool_keyword\" may slow down scanning"
time=2024-05-05T20:04:34.763-05:00 level=DEBUG source=/Users/egibs/repos/bincapz/pkg/action/scan.go:105 msg=scan config="{ExcludePaths:[bincapz] IncludePaths:[] IgnoreTags:[] IncludeDataFiles:false MinFileScore:0 MinResultScore:1 OCI:false OmitEmpty:false Output:<nil> Renderer:{w:0x14000062050} Rules:0x1400032a2b8 ScanPaths:[bincapz] Stats:false}"
time=2024-05-05T20:04:34.763-05:00 level=INFO source=/Users/egibs/repos/bincapz/pkg/action/scan.go:118 msg="14531 rules loaded"
time=2024-05-05T20:04:34.763-05:00 level=INFO source=/Users/egibs/repos/bincapz/pkg/action/scan.go:23 msg="finding files in bincapz ..."
```

Including a sub-path:
```
❯ go run . --format simple bincapz/- samples/+
#
# samples/Linux/2021.ua-parser-js/preinstall.js
exec/program
kernel/uname/get
shell/exec
techniques/code_eval
third_party/mthcht_thk_yara_rules
# samples/Linux/2021.ua-parser-js/preinstall.sh
3P/signature_base/pua/crypto
combo/dropper/shell
crypto/mining/generic
fs/file/make_executable
fs/permission/modify
net/download
net/fetch
net/fetch/insecure
net/fetch/suspicious
net/geoip
process/find
ref/ip
ref/path/relative
ref/site/http/ip
ref/site/url
third_party/mthcht_thk_yara_rules
# samples/Linux/2022.Magneto/magnet_goblin_dropper.sh
...
```