### PR TITLE
Disable poorly performing rules, including those with warnings

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -17,6 +17,23 @@ import (
 
 var FS = rules.FS
 
+// badRules are noisy 3rd party rules to silently disable.
+var badRules = map[string]bool{
+	"GODMODERULES_IDDQD_God_Mode_Rule": true,
+}
+
+// rulesWithWarnings determines what to do with rules that have known warnings: true=keep, false=disable.
+var rulesWithWarnings = map[string]bool{
+	"opaque_binary":                         true,
+	"hardcoded_ip":                          true,
+	"hardcoded_ip_port":                     true,
+	"systemd_no_comments_or_documentation":  true,
+	"sleep_and_background":                  true,
+	"RDPassSpray_offensive_tool_keyword":    false,
+	"nmap_offensive_tool_keyword":           false,
+	"DynastyPersist_offensive_tool_keyword": false,
+}
+
 func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 	yc, err := yara.NewCompiler()
 	if err != nil {
@@ -56,12 +73,46 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 		return nil, fmt.Errorf("walk: %w", err)
 	}
 
+	warnings := map[string]string{}
 	for _, ycw := range yc.Warnings {
-		clog.WarnContext(ctx, "warning", slog.String("namespace", ycw.Rule.Namespace()), slog.String("warning", ycw.Text))
+		clog.WarnContext(ctx, "warning", slog.String("namespace", ycw.Rule.Namespace()), slog.String("warning", ycw.Text), slog.String("id", ycw.Rule.Identifier()))
+		id := fmt.Sprintf("%s:%s", ycw.Rule.Namespace(), ycw.Rule.Identifier())
+		warnings[id] = ycw.Text
 	}
 
 	for _, yce := range yc.Errors {
-		clog.ErrorContext(ctx, "errors", slog.String("namespace", yce.Rule.Namespace()), slog.String("error", yce.Text))
+		clog.ErrorContext(ctx, "errors", slog.String("namespace", yce.Rule.Namespace()), slog.String("error", yce.Text), slog.String("id", yce.Rule.Identifier()))
+		return nil, fmt.Errorf("rule error: %v", yce.Text)
+	}
+
+	rs, err := yc.GetRules()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, r := range rs.GetRules() {
+		if badRules[r.Identifier()] {
+			clog.InfoContext(ctx, "info", slog.String("namespace", r.Namespace()), slog.String("id", r.Identifier()), slog.String("reason", "disabled (known bad rule)"))
+			r.Disable()
+		}
+
+		id := fmt.Sprintf("%s:%s", r.Namespace(), r.Identifier())
+		warning := warnings[id]
+		if warning == "" {
+			continue
+		}
+
+		// use rule name instead of filename to lower maintenance in the face of renames
+		keep, known := rulesWithWarnings[r.Identifier()]
+		if keep {
+			continue
+		}
+		if !known {
+			clog.ErrorContext(ctx, "error", slog.String("namespace", r.Namespace()), slog.String("id", r.Identifier()), slog.String("disabled due to unexpected warning", warnings[id]))
+		} else {
+			clog.InfoContext(ctx, "info", slog.String("namespace", r.Namespace()), slog.String("id", r.Identifier()), slog.String("disabled due to expected warning", warnings[id]))
+		}
+		r.Disable()
 	}
 
 	return yc.GetRules()

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -115,5 +115,5 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 		r.Disable()
 	}
 
-	return yc.GetRules()
+	return rs, nil
 }

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -60,12 +60,6 @@ var yaraForgeJunkWords = map[string]bool{
 	"greyware":          true,
 }
 
-// dropRules are noisy 3rd party rules to silently ignore.
-var dropRules = map[string]bool{
-	"3P/godmoderules/iddqd/god/mode":         true,
-	"3P/threat_hunting_keywords/rdpassspray": true,
-}
-
 // authorWithURLRe matcehs "Arnim Rupp (https://github.com/ruppde)"
 var authorWithURLRe = regexp.MustCompile(`(.*?) \((http.*)\)`)
 
@@ -312,10 +306,6 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, ignoreTags 
 			continue
 		}
 		key := generateKey(m.Namespace, m.Rule)
-		if dropRules[key] {
-			continue
-		}
-
 		ruleURL := generateRuleURL(m.Namespace, m.Rule)
 		packageRisks = append(packageRisks, key)
 

--- a/rules/ref/email.yara
+++ b/rules/ref/email.yara
@@ -1,12 +1,3 @@
-rule email_addr : harmless {
-  meta:
-	description = "Contains an email address"
-  strings:
-    $e_re = /[\w\.]{1,32}[a-z]@[a-z][\w\.\-]{1,64}\.[a-z]{2,5}/ fullword
-  condition:
-    any of ($e*)
-}
-
 rule exotic_email_addr : notable {
   meta:
 	description = "Contains an exotic email address"

--- a/samples/macOS/clean/ls.json
+++ b/samples/macOS/clean/ls.json
@@ -1,0 +1,65 @@
+{
+    "Files": {
+        "macOS/clean/ls": {
+            "Path": "macOS/clean/ls",
+            "SHA256": "461b7ef5288c9c4b0d10aefc9ca42f7ddab9954a3f3d032e3a783e3da0c970b6",
+            "Meta": {
+                "format": "macho",
+                "meta": "program_name"
+            },
+            "Syscalls": [
+                "getdents",
+                "openat",
+                "readlink"
+            ],
+            "Pledge": [
+                "rpath"
+            ],
+            "Behaviors": {
+                "env/TERM": {
+                    "Description": "Look up or override terminal settings",
+                    "MatchStrings": [
+                        "TERM"
+                    ],
+                    "RiskScore": 1,
+                    "RiskLevel": "LOW",
+                    "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/env/TERM.yara#TERM",
+                    "ReferenceURL": "https://www.gnu.org/software/gettext/manual/html_node/The-TERM-variable.html"
+                },
+                "fs/directory/traverse": {
+                    "Description": "traverse filesystem hierarchy",
+                    "MatchStrings": [
+                        "_fts_children",
+                        "_fts_close",
+                        "_fts_open",
+                        "_fts_read",
+                        "_fts_set"
+                    ],
+                    "RiskScore": 1,
+                    "RiskLevel": "LOW",
+                    "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/fs/directory-traverse.yara#fts"
+                },
+                "fs/link/read": {
+                    "Description": "read value of a symbolic link",
+                    "MatchStrings": [
+                        "readlink"
+                    ],
+                    "RiskScore": 1,
+                    "RiskLevel": "LOW",
+                    "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/fs/link-read.yara#readlink",
+                    "ReferenceURL": "https://man7.org/linux/man-pages/man2/readlink.2.html"
+                }
+            },
+            "RiskScore": 1,
+            "RiskLevel": "LOW",
+            "PackageRisk": [
+                "env/TERM",
+                "fs/directory/traverse",
+                "fs/link/read",
+                "meta/format/macho",
+                "meta/program_name"
+            ]
+        }
+    },
+    "Diff": {}
+}

--- a/samples/macOS/clean/ls.mdiff
+++ b/samples/macOS/clean/ls.mdiff
@@ -1,4 +1,4 @@
-## Changed: .
+## Changed: . [⚠️ MEDIUM → ✅ LOW]
 
 ### 1 new behaviors
 

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -6,7 +6,6 @@ package samples
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"io/fs"
 	"log/slog"
 	"os"
@@ -15,7 +14,6 @@ import (
 	"testing"
 
 	"github.com/chainguard-dev/bincapz/pkg/action"
-	"github.com/chainguard-dev/bincapz/pkg/bincapz"
 	"github.com/chainguard-dev/bincapz/pkg/compile"
 	"github.com/chainguard-dev/bincapz/pkg/render"
 	"github.com/chainguard-dev/bincapz/rules"
@@ -31,7 +29,7 @@ func TestJSON(t *testing.T) {
 	ctx := slogtest.TestContextWithLogger(t)
 	clog.FromContext(ctx).With("test", "TestJSON")
 
-	yrs, err := compile.Recursive(ctx, []fs.FS{rules.FS})
+	yrs, err := compile.Recursive(ctx, []fs.FS{rules.FS, thirdparty.FS})
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
@@ -55,11 +53,7 @@ func TestJSON(t *testing.T) {
 			if err != nil {
 				t.Fatalf("testdata read failed: %v", err)
 			}
-
-			var want bincapz.Report
-			if err := json.Unmarshal(td, &want); err != nil {
-				t.Fatalf("testdata unmarshal: %v", err)
-			}
+			want := string(td)
 
 			var out bytes.Buffer
 			render, err := render.New("json", &out)
@@ -67,22 +61,27 @@ func TestJSON(t *testing.T) {
 				t.Fatalf("render: %v", err)
 			}
 			bc := action.Config{
-				IgnoreSelf: false,
-				IgnoreTags: []string{"harmless"},
-				Renderer:   render,
-				Rules:      yrs,
-				ScanPaths:  []string{binPath},
+				IgnoreSelf:     false,
+				Renderer:       render,
+				Rules:          yrs,
+				MinResultScore: 1,
+				ScanPaths:      []string{binPath},
 			}
 
 			tcLogger := clog.FromContext(ctx).With("test", name)
 			ctx := clog.WithLogger(ctx, tcLogger)
-			got, err := action.Scan(ctx, bc)
+			res, err := action.Scan(ctx, bc)
 			if err != nil {
 				t.Fatalf("scan failed: %v", err)
 			}
 
+			if err := render.Full(ctx, *res); err != nil {
+				t.Fatalf("full: %v", err)
+			}
+
+			got := out.String()
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("JSON output mismatch: (-want +got):\n%s", diff)
+				t.Errorf("markdown output mismatch: (-want +got):\n%s", diff)
 			}
 		})
 		return nil


### PR DESCRIPTION
Old behavior:
- Rules marked as bad were still executed. These results were used in the file risk calculation even if we later hid the matching rule result (see "ls.mdiff" test result)
- Rules with warnings were still executed, with the warning hidden unless `-verbose` was passed.

New behavior:
- Rules marked as bad are disabled
- Rules with warnings are:
  - Disabled unless there is an exception
  - If an unexpected rule has a warning, log an error

Other notes:
- I've removed the e-mail rule, as it had a warning and wasn't useful
- I brought JSON tests back from the dead to prove the "ls" data. We had purged these tests a while back when the JSON output wasn't yet stable.
- This PR does not provide a performance improvement or regression, but it does fix a bug!