### PR TITLE
Add profiling to help with OOM/performance investigations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ out/
 
 # macOS
 *.DS_Store
+
+# Profiling data
+profiles/

--- a/README.md
+++ b/README.md
@@ -169,6 +169,23 @@ If you find malware that `bincapz` doesn't surface suspicious behaviors for, sen
 
 ### Troubleshooting
 
+#### Profiling
+
+`bincapz` can be profiled by running `--profile=true`. This will generate timestamped profiles in an untracked `profiles` directory:
+```
+bash-5.2$ ls -l profiles/ | grep -v "total" | awk '{ print $9 }'
+cpu_329605000.pprof
+mem_329605000.pprof
+trace_329605000.out
+```
+
+The traces can be inspected via `go tool pprof` and `go tool trace`.
+
+For example, the memory profile can be inspected by running:
+```
+go tool pprof -http=:8080 profiles/mem_<timestamp>.pprof
+```
+
 #### Error: ld: library 'yara' not found
 
 If you get this error at installation:

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -1,0 +1,87 @@
+package profile
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"runtime/trace"
+	"time"
+)
+
+func Profile() (func(), error) {
+	timestamp := time.Now().Nanosecond()
+
+	// Create the profiles directory if it does not already exist
+	if _, err := os.Stat("profiles"); os.IsNotExist(err) {
+		err := os.Mkdir("profiles", 0o755)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create profiles directory: %w", err)
+		}
+	}
+
+	// Create the CPU profile
+	c, err := os.Create(filepath.Join("profiles", fmt.Sprintf("cpu_%d.pprof", timestamp)))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CPU profile: %w", err)
+	}
+
+	// Start the CPU profiling
+	err = pprof.StartCPUProfile(c)
+	if err != nil {
+		c.Close()
+		return nil, fmt.Errorf("failed to start CPU profile: %w", err)
+	}
+
+	// Create the memory profile
+	m, err := os.Create(filepath.Join("profiles", fmt.Sprintf("mem_%d.pprof", timestamp)))
+	if err != nil {
+		c.Close()
+		m.Close()
+		return nil, fmt.Errorf("failed to create memory profile: %w", err)
+	}
+
+	// Create the trace file
+	t, err := os.Create(filepath.Join("profiles", fmt.Sprintf("trace_%d.out", timestamp)))
+	if err != nil {
+		c.Close()
+		m.Close()
+		t.Close()
+		return nil, fmt.Errorf("failed to create trace file: %w", err)
+	}
+
+	// Start tracing
+	err = trace.Start(t)
+	if err != nil {
+		c.Close()
+		m.Close()
+		t.Close()
+		return nil, fmt.Errorf("failed to start trace: %w", err)
+	}
+
+	// Handle cleanup for profiling, tracing, and file closures
+	stop := func() {
+		pprof.StopCPUProfile()
+		if err := pprof.WriteHeapProfile(m); err != nil {
+			fmt.Fprintf(os.Stderr, "failed to write memory profile: %v\n", err)
+		}
+		trace.Stop()
+		c.Close()
+		m.Close()
+		t.Close()
+	}
+
+	return stop, nil
+}
+
+func HandleProfileFlag(pf *bool) error {
+	if *pf {
+		stop, err := Profile()
+		if err != nil {
+			return err
+		}
+		defer stop()
+	}
+
+	return nil
+}

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func profile() (func(), error) {
+func Profile() (func(), error) {
 	timestamp := time.Now().Nanosecond()
 
 	// Create the profiles directory if it does not already exist
@@ -72,16 +72,4 @@ func profile() (func(), error) {
 	}
 
 	return stop, nil
-}
-
-func HandleProfileFlag(pf *bool) error {
-	if *pf {
-		stop, err := profile()
-		if err != nil {
-			return err
-		}
-		defer stop()
-	}
-
-	return nil
 }

--- a/pkg/profile/profile.go
+++ b/pkg/profile/profile.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-func Profile() (func(), error) {
+func profile() (func(), error) {
 	timestamp := time.Now().Nanosecond()
 
 	// Create the profiles directory if it does not already exist
@@ -76,7 +76,7 @@ func Profile() (func(), error) {
 
 func HandleProfileFlag(pf *bool) error {
 	if *pf {
-		stop, err := Profile()
+		stop, err := profile()
 		if err != nil {
 			return err
 		}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -2,5 +2,5 @@ package rules
 
 import "embed"
 
-//go:embed *
+//go:embed */*
 var FS embed.FS


### PR DESCRIPTION
This is a quick PR to help with identifying the cause(s) of #204 which adds CPU and Memory profiling along with tracing.

If anything, I wanted the code to be available to aid with the investigation -- this doesn't necessarily need to be merged; however, as the number of capabilities grows it would be nice to have some insight into any causes of performance regressions.