### PR TITLE
Reduce memory usage by 30% through use of pointers

### DIFF
--- a/bincapz.go
+++ b/bincapz.go
@@ -120,7 +120,7 @@ func main() {
 		log.Fatal("failed", slog.Any("error", err))
 	}
 
-	err = renderer.Full(ctx, *res)
+	err = renderer.Full(ctx, res)
 	if err != nil {
 		log.Fatal("render failed", slog.Any("error", err))
 	}

--- a/pkg/action/diff.go
+++ b/pkg/action/diff.go
@@ -14,7 +14,7 @@ import (
 	"github.com/chainguard-dev/clog"
 )
 
-func relFileReport(ctx context.Context, c Config, path string) (map[string]bincapz.FileReport, error) {
+func relFileReport(ctx context.Context, c Config, path string) (map[string]*bincapz.FileReport, error) {
 	fromPath := path
 	fromConfig := c
 	fromConfig.Renderer = nil
@@ -23,7 +23,7 @@ func relFileReport(ctx context.Context, c Config, path string) (map[string]binca
 	if err != nil {
 		return nil, err
 	}
-	fromRelPath := map[string]bincapz.FileReport{}
+	fromRelPath := map[string]*bincapz.FileReport{}
 	for _, f := range fromReport.Files {
 		if f.Skipped != "" || f.Error != "" {
 			continue
@@ -54,10 +54,10 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 		return nil, err
 	}
 
-	d := bincapz.DiffReport{
-		Added:    map[string]bincapz.FileReport{},
-		Removed:  map[string]bincapz.FileReport{},
-		Modified: map[string]bincapz.FileReport{},
+	d := &bincapz.DiffReport{
+		Added:    map[string]*bincapz.FileReport{},
+		Removed:  map[string]*bincapz.FileReport{},
+		Modified: map[string]*bincapz.FileReport{},
 	}
 
 	// things that appear in the source
@@ -73,9 +73,9 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 			continue
 		}
 
-		rbs := bincapz.FileReport{
+		rbs := &bincapz.FileReport{
 			Path:              tr.Path,
-			Behaviors:         map[string]bincapz.Behavior{},
+			Behaviors:         map[string]*bincapz.Behavior{},
 			PreviousRiskScore: fr.RiskScore,
 			PreviousRiskLevel: fr.RiskLevel,
 			RiskLevel:         tr.RiskLevel,
@@ -107,9 +107,9 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 			continue
 		}
 
-		abs := bincapz.FileReport{
+		abs := &bincapz.FileReport{
 			Path:              tr.Path,
-			Behaviors:         map[string]bincapz.Behavior{},
+			Behaviors:         map[string]*bincapz.Behavior{},
 			PreviousRiskScore: fr.RiskScore,
 			PreviousRiskLevel: fr.RiskLevel,
 
@@ -151,12 +151,12 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 			}
 
 			// We think that this file moved from rpath to apath.
-			abs := bincapz.FileReport{
+			abs := &bincapz.FileReport{
 				Path:                 tr.Path,
 				PreviousRelPath:      rpath,
 				PreviousRelPathScore: score,
 
-				Behaviors:         map[string]bincapz.Behavior{},
+				Behaviors:         map[string]*bincapz.Behavior{},
 				PreviousRiskScore: fr.RiskScore,
 				PreviousRiskLevel: fr.RiskLevel,
 

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -89,7 +89,7 @@ func recursiveScan(ctx context.Context, c Config) (*bincapz.Report, error) {
 	logger := clog.FromContext(ctx)
 	logger.Debug("scan", slog.Any("config", c))
 	r := &bincapz.Report{
-		Files: map[string]bincapz.FileReport{},
+		Files: map[string]*bincapz.FileReport{},
 	}
 	if len(c.IgnoreTags) > 0 {
 		r.Filter = strings.Join(c.IgnoreTags, ",")
@@ -194,11 +194,11 @@ func processFile(
 		if fr.RiskScore < c.MinFileScore {
 			return nil
 		}
-		if err := c.Renderer.File(ctx, *fr); err != nil {
+		if err := c.Renderer.File(ctx, fr); err != nil {
 			return fmt.Errorf("render: %w", err)
 		}
 	}
-	r.Files[path] = *fr
+	r.Files[path] = fr
 	return nil
 }
 

--- a/pkg/bincapz/bincapz.go
+++ b/pkg/bincapz/bincapz.go
@@ -27,14 +27,14 @@ type FileReport struct {
 	Path   string
 	SHA256 string
 	// compiler -> x
-	Error             string              `json:",omitempty" yaml:",omitempty"`
-	Skipped           string              `json:",omitempty" yaml:",omitempty"`
-	Meta              map[string]string   `json:",omitempty" yaml:",omitempty"`
-	Syscalls          []string            `json:",omitempty" yaml:",omitempty"`
-	Pledge            []string            `json:",omitempty" yaml:",omitempty"`
-	Capabilities      []string            `json:",omitempty" yaml:",omitempty"`
-	Behaviors         map[string]Behavior `json:",omitempty" yaml:",omitempty"`
-	FilteredBehaviors int                 `json:",omitempty" yaml:",omitempty"`
+	Error             string               `json:",omitempty" yaml:",omitempty"`
+	Skipped           string               `json:",omitempty" yaml:",omitempty"`
+	Meta              map[string]string    `json:",omitempty" yaml:",omitempty"`
+	Syscalls          []string             `json:",omitempty" yaml:",omitempty"`
+	Pledge            []string             `json:",omitempty" yaml:",omitempty"`
+	Capabilities      []string             `json:",omitempty" yaml:",omitempty"`
+	Behaviors         map[string]*Behavior `json:",omitempty" yaml:",omitempty"`
+	FilteredBehaviors int                  `json:",omitempty" yaml:",omitempty"`
 
 	// The relative path we think this moved from.
 	PreviousRelPath string `json:",omitempty" yaml:",omitempty"`
@@ -43,23 +43,22 @@ type FileReport struct {
 	PreviousRiskScore    int     `json:",omitempty" yaml:",omitempty"`
 	PreviousRiskLevel    string  `json:",omitempty" yaml:",omitempty"`
 
-	RiskScore   int
-	RiskLevel   string   `json:",omitempty" yaml:",omitempty"`
-	PackageRisk []string `json:",omitempty" yaml:",omitempty"`
+	RiskScore int
+	RiskLevel string `json:",omitempty" yaml:",omitempty"`
 
 	IsBincapz bool `json:",omitempty" yaml:",omitempty"`
 }
 
 type DiffReport struct {
-	Added    map[string]FileReport `json:",omitempty" yaml:",omitempty"`
-	Removed  map[string]FileReport `json:",omitempty" yaml:",omitempty"`
-	Modified map[string]FileReport `json:",omitempty" yaml:",omitempty"`
+	Added    map[string]*FileReport `json:",omitempty" yaml:",omitempty"`
+	Removed  map[string]*FileReport `json:",omitempty" yaml:",omitempty"`
+	Modified map[string]*FileReport `json:",omitempty" yaml:",omitempty"`
 }
 
 type Report struct {
-	Files  map[string]FileReport `json:",omitempty" yaml:",omitempty"`
-	Diff   DiffReport            `json:",omitempty" yaml:",omitempty"`
-	Filter string                `json:",omitempty" yaml:",omitempty"`
+	Files  map[string]*FileReport `json:",omitempty" yaml:",omitempty"`
+	Diff   *DiffReport            `json:",omitempty" yaml:",omitempty"`
+	Filter string                 `json:",omitempty" yaml:",omitempty"`
 }
 
 type IntMetric struct {

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -20,11 +20,11 @@ func NewJSON(w io.Writer) JSON {
 	return JSON{w: w}
 }
 
-func (r JSON) File(_ context.Context, _ bincapz.FileReport) error {
+func (r JSON) File(_ context.Context, _ *bincapz.FileReport) error {
 	return nil
 }
 
-func (r JSON) Full(_ context.Context, rep bincapz.Report) error {
+func (r JSON) Full(_ context.Context, rep *bincapz.Report) error {
 	j, err := json.MarshalIndent(rep, "", "    ")
 	if err != nil {
 		return err

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -47,6 +47,10 @@ func (r Markdown) File(ctx context.Context, fr *bincapz.FileReport) error {
 }
 
 func (r Markdown) Full(ctx context.Context, rep *bincapz.Report) error {
+	if rep.Diff == nil {
+		return nil
+	}
+
 	for f, fr := range rep.Diff.Removed {
 		fr := fr
 		markdownTable(ctx, fr, r.w, tableConfig{Title: fmt.Sprintf("## Deleted: %s [%s]", f, mdRisk(fr.RiskScore, fr.RiskLevel)), DiffRemoved: true})

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -41,20 +41,20 @@ func matchFragmentLink(s string) string {
 	return fmt.Sprintf("[%s](https://github.com/search?q=%s&type=code)", s, url.QueryEscape(s))
 }
 
-func (r Markdown) File(ctx context.Context, fr bincapz.FileReport) error {
-	markdownTable(ctx, &fr, r.w, tableConfig{Title: fmt.Sprintf("## %s [%s]", fr.Path, mdRisk(fr.RiskScore, fr.RiskLevel))})
+func (r Markdown) File(ctx context.Context, fr *bincapz.FileReport) error {
+	markdownTable(ctx, fr, r.w, tableConfig{Title: fmt.Sprintf("## %s [%s]", fr.Path, mdRisk(fr.RiskScore, fr.RiskLevel))})
 	return nil
 }
 
-func (r Markdown) Full(ctx context.Context, rep bincapz.Report) error {
+func (r Markdown) Full(ctx context.Context, rep *bincapz.Report) error {
 	for f, fr := range rep.Diff.Removed {
 		fr := fr
-		markdownTable(ctx, &fr, r.w, tableConfig{Title: fmt.Sprintf("## Deleted: %s [%s]", f, mdRisk(fr.RiskScore, fr.RiskLevel)), DiffRemoved: true})
+		markdownTable(ctx, fr, r.w, tableConfig{Title: fmt.Sprintf("## Deleted: %s [%s]", f, mdRisk(fr.RiskScore, fr.RiskLevel)), DiffRemoved: true})
 	}
 
 	for f, fr := range rep.Diff.Added {
 		fr := fr
-		markdownTable(ctx, &fr, r.w, tableConfig{Title: fmt.Sprintf("## Added: %s [%s]", f, mdRisk(fr.RiskScore, fr.RiskLevel)), DiffAdded: true})
+		markdownTable(ctx, fr, r.w, tableConfig{Title: fmt.Sprintf("## Added: %s [%s]", f, mdRisk(fr.RiskScore, fr.RiskLevel)), DiffAdded: true})
 	}
 
 	for f, fr := range rep.Diff.Modified {
@@ -85,14 +85,14 @@ func (r Markdown) Full(ctx context.Context, rep bincapz.Report) error {
 		}
 
 		if added > 0 {
-			markdownTable(ctx, &fr, r.w, tableConfig{
+			markdownTable(ctx, fr, r.w, tableConfig{
 				Title:       fmt.Sprintf("### %d new behaviors", added),
 				SkipRemoved: true,
 			})
 		}
 
 		if removed > 0 {
-			markdownTable(ctx, &fr, r.w, tableConfig{
+			markdownTable(ctx, fr, r.w, tableConfig{
 				Title:     fmt.Sprintf("### %d removed behaviors", removed),
 				SkipAdded: true,
 			})

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -13,8 +13,8 @@ import (
 
 // Renderer is a common interface for Renderers.
 type Renderer interface {
-	File(context.Context, bincapz.FileReport) error
-	Full(context.Context, bincapz.Report) error
+	File(context.Context, *bincapz.FileReport) error
+	Full(context.Context, *bincapz.Report) error
 }
 
 // New returns a new Renderer.

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -20,7 +20,7 @@ func NewSimple(w io.Writer) Simple {
 	return Simple{w: w}
 }
 
-func (r Simple) File(_ context.Context, fr bincapz.FileReport) error {
+func (r Simple) File(_ context.Context, fr *bincapz.FileReport) error {
 	fmt.Fprintf(r.w, "# %s\n", fr.Path)
 	bs := []string{}
 
@@ -34,7 +34,7 @@ func (r Simple) File(_ context.Context, fr bincapz.FileReport) error {
 	return nil
 }
 
-func (r Simple) Full(_ context.Context, rep bincapz.Report) error {
+func (r Simple) Full(_ context.Context, rep *bincapz.Report) error {
 	for f, fr := range rep.Diff.Removed {
 		fmt.Fprintf(r.w, "--- missing: %s\n", f)
 

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -35,6 +35,10 @@ func (r Simple) File(_ context.Context, fr *bincapz.FileReport) error {
 }
 
 func (r Simple) Full(_ context.Context, rep *bincapz.Report) error {
+	if rep.Diff == nil {
+		return nil
+	}
+
 	for f, fr := range rep.Diff.Removed {
 		fmt.Fprintf(r.w, "--- missing: %s\n", f)
 

--- a/pkg/render/stats.go
+++ b/pkg/render/stats.go
@@ -8,7 +8,7 @@ import (
 	"github.com/chainguard-dev/bincapz/pkg/report"
 )
 
-func riskStatistics(files map[string]bincapz.FileReport) ([]bincapz.IntMetric, int, int) {
+func riskStatistics(files map[string]*bincapz.FileReport) ([]bincapz.IntMetric, int, int) {
 	riskMap := make(map[int][]string)
 	riskStats := make(map[int]float64)
 
@@ -49,12 +49,12 @@ func riskStatistics(files map[string]bincapz.FileReport) ([]bincapz.IntMetric, i
 	return stats, total(), processedFiles
 }
 
-func pkgStatistics(files map[string]bincapz.FileReport) ([]bincapz.StrMetric, int, int) {
+func pkgStatistics(files map[string]*bincapz.FileReport) ([]bincapz.StrMetric, int, int) {
 	numNamespaces := 0
 	pkgMap := make(map[string]int)
 	pkg := make(map[string]float64)
 	for _, rf := range files {
-		for _, namespace := range rf.PackageRisk {
+		for namespace := range rf.Behaviors {
 			numNamespaces++
 			pkgMap[namespace]++
 		}

--- a/pkg/render/yaml.go
+++ b/pkg/render/yaml.go
@@ -20,11 +20,11 @@ func NewYAML(w io.Writer) YAML {
 	return YAML{w: w}
 }
 
-func (r YAML) File(_ context.Context, _ bincapz.FileReport) error {
+func (r YAML) File(_ context.Context, _ *bincapz.FileReport) error {
 	return nil
 }
 
-func (r YAML) Full(_ context.Context, rep bincapz.Report) error {
+func (r YAML) Full(_ context.Context, rep *bincapz.Report) error {
 	yaml, err := yaml.Marshal(rep)
 	if err != nil {
 		return err

--- a/samples/macOS/clean/ls.json
+++ b/samples/macOS/clean/ls.json
@@ -51,15 +51,7 @@
                 }
             },
             "RiskScore": 1,
-            "RiskLevel": "LOW",
-            "PackageRisk": [
-                "env/TERM",
-                "fs/directory/traverse",
-                "fs/link/read",
-                "meta/format/macho",
-                "meta/program_name"
-            ]
+            "RiskLevel": "LOW"
         }
-    },
-    "Diff": {}
+    }
 }

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -76,7 +76,7 @@ func TestJSON(t *testing.T) {
 				t.Fatalf("scan failed: %v", err)
 			}
 
-			if err := render.Full(ctx, *res); err != nil {
+			if err := render.Full(ctx, res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 
@@ -140,7 +140,7 @@ func TestSimple(t *testing.T) {
 				t.Fatalf("scan failed: %v", err)
 			}
 
-			if err := simple.Full(ctx, *res); err != nil {
+			if err := simple.Full(ctx, res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 
@@ -213,7 +213,7 @@ func TestDiff(t *testing.T) {
 				t.Fatalf("diff failed: %v", err)
 			}
 
-			if err := simple.Full(ctx, *res); err != nil {
+			if err := simple.Full(ctx, res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 
@@ -287,7 +287,7 @@ func TestMarkdown(t *testing.T) {
 				t.Fatalf("scan failed: %v", err)
 			}
 
-			if err := simple.Full(ctx, *res); err != nil {
+			if err := simple.Full(ctx, res); err != nil {
 				t.Fatalf("full: %v", err)
 			}
 


### PR DESCRIPTION
This PR changes it so that larger data structures are always passed by reference.

It also removes the `FileReport.PackageRisk`, as it showed up in the memory trace and seemed duplicative of the keys in `FileReport.Behaviors`.

When run against a directory with 19,000 files, this PR reduced memory usage from 100MB to 69MB.

Part of #204 
