### PR TITLE
Fix archive extraction

### DIFF
--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -279,7 +279,8 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 		return "", fmt.Errorf("failed to create temp dir: %w", err)
 	}
 
-	extract := extractionMethod(filepath.Ext(path))
+	ext := getExt(path)
+	extract := extractionMethod(ext)
 	if extract == nil {
 		return "", fmt.Errorf("unsupported archive type: %s", path)
 	}


### PR DESCRIPTION
Closes: #212

`filepath.Ext(path)` does not handle multi-suffix file extensions (e.g. `.tar.gz`). 

This PR uses `getExt` instead (I should have noticed this in #205 but I was testing with `.gem` files).

I confirmed that this is working.

Original:
```
❯ go run . --format simple /Users/egibs/Downloads/apko_0.13.2_darwin_amd64.tar.gz
time=2024-05-10T15:03:10.707-05:00 level=ERROR msg="unable to process /Users/egibs/Downloads/apko_0.13.2_darwin_amd64.tar.gz: extract to temp: extract: failed to extract nested archive: failed to create gzip reader: gzip: invalid header"

```

Fixed:
```
❯ go run . --format simple /Users/egibs/Downloads/apko_0.13.2_darwin_amd64.tar.gz
#
# /var/folders/3g/88131l9j11x995ppjbxsvhbh0000gn/T/apko_0.13.2_darwin_amd64.tar.gz1508281868/apko_0.13.2_darwin_amd64/apko
archives/zip
combo/dropper/shell
combo/stealer/ssh
compression/bzip2
compression/gzip
compression/zstd
crypto/aes
crypto/ecdsa
crypto/ed25519
crypto/tls
data/embedded/pem/certificate
data/embedded/pem/test_key
data/embedded/ssh/signature
data/embedded/zstd
encoding/base64
encoding/json
encoding/json/decode
encoding/json/encode
env/HOME
env/USER
evasion/content/length/0
exec/program
fs/blkid
fs/directory/create
fs/directory/list
fs/directory/remove
fs/fifo/create
fs/file/delete
fs/file/read
fs/file/stat
fs/file/truncate
fs/file/write
fs/link/create
fs/link/read
fs/lock/update
fs/mount
fs/node/create
fs/permission/chown
fs/permission/modify
fs/swap/off
fs/swap/on
fs/symlink/resolve
fs/tempfile/create
fs/unmount
hash/blake2b
hash/md5
kernel/cpu/info
kernel/pivot_root
kernel/platform
kernel/ptrace
net/dns
net/dns/reverse
net/dns/txt
net/download
net/fetch
net/hostname/resolve
net/hostport/parse
net/http/accept/encoding
net/http/auth
net/http/cookies
net/http/form/upload
net/http/post
net/http/request
net/http2
net/http_proxy
net/interface/list
net/ip
net/ip/multicast/send
net/ip/parse
net/mac/address
net/sendfile
net/socket/connect
net/socket/listen
net/socket/local/address
net/socket/peer/address
net/socket/receive
net/socket/send
net/socks5
net/ssh
net/stat
net/udp/receive
net/udp/send
net/upload
net/url
net/url/encode
net/url/request
process/chroot
process/create
process/find
process/multithreaded
process/unshare
process/username/get
ref/daemon
ref/ip_port
ref/path/bin/su
ref/path/etc
ref/path/etc/hosts
ref/path/etc/resolv.conf
ref/path/hidden
ref/path/home
ref/path/home/config
ref/path/relative
ref/path/root
ref/path/users
ref/path/usr/bin
ref/path/usr/local
ref/path/usr/sbin
ref/path/var
ref/site/url
ref/words/exclamation
ref/words/heartbeat
ref/words/password
ref/words/plugin
ref/words/server_address
secrets/keychain
secrets/private_key
secrets/ssh
security_controls/linux/selinux
shell/background/sleep
shell/exec
time/clock/set
```