### PR TITLE
Replace Behavior map with slice

### DIFF
--- a/pkg/action/diff.go
+++ b/pkg/action/diff.go
@@ -76,7 +76,7 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 
 		rbs := &bincapz.FileReport{
 			Path:              tr.Path,
-			Behaviors:         map[string]*bincapz.Behavior{},
+			Behaviors:         []*bincapz.Behavior{},
 			PreviousRiskScore: fr.RiskScore,
 			PreviousRiskLevel: fr.RiskLevel,
 			RiskLevel:         tr.RiskLevel,
@@ -84,10 +84,17 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 		}
 
 		// if source behavior is not in the destination
-		for key, b := range fr.Behaviors {
-			if _, exists := tr.Behaviors[key]; !exists {
-				b.DiffRemoved = true
-				rbs.Behaviors[key] = b
+		for _, fb := range fr.Behaviors {
+			found := false
+			for _, tb := range tr.Behaviors {
+				if tb.Evidence == fb.Evidence {
+					found = true
+					break
+				}
+			}
+			if !found {
+				fb.DiffRemoved = true
+				rbs.Behaviors = append(rbs.Behaviors, fb)
 			}
 		}
 
@@ -110,7 +117,7 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 
 		abs := &bincapz.FileReport{
 			Path:              tr.Path,
-			Behaviors:         map[string]*bincapz.Behavior{},
+			Behaviors:         []*bincapz.Behavior{},
 			PreviousRiskScore: fr.RiskScore,
 			PreviousRiskLevel: fr.RiskLevel,
 
@@ -119,10 +126,17 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 		}
 
 		// if destination behavior is not in the source
-		for key, b := range tr.Behaviors {
-			if _, exists := fr.Behaviors[key]; !exists {
-				b.DiffAdded = true
-				abs.Behaviors[key] = b
+		for _, tb := range tr.Behaviors {
+			found := false
+			for _, fb := range fr.Behaviors {
+				if len(fr.Behaviors) > 0 && tb.Evidence == fb.Evidence {
+					found = true
+					break
+				}
+			}
+			if !found {
+				tb.DiffAdded = true
+				abs.Behaviors = append(abs.Behaviors, tb)
 			}
 		}
 
@@ -130,8 +144,8 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 		if _, exists := d.Modified[relPath]; !exists {
 			d.Modified[relPath] = abs
 		} else {
-			for key, b := range abs.Behaviors {
-				d.Modified[relPath].Behaviors[key] = b
+			for _, b := range abs.Behaviors {
+				d.Modified[relPath].Behaviors = append(d.Modified[relPath].Behaviors, b)
 			}
 		}
 	}
@@ -167,7 +181,7 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 				PreviousRelPath:      rpath,
 				PreviousRelPathScore: score,
 
-				Behaviors:         map[string]*bincapz.Behavior{},
+				Behaviors:         []*bincapz.Behavior{},
 				PreviousRiskScore: fr.RiskScore,
 				PreviousRiskLevel: fr.RiskLevel,
 
@@ -176,18 +190,32 @@ func Diff(ctx context.Context, c Config) (*bincapz.Report, error) {
 			}
 
 			// if destination behavior is not in the source
-			for key, b := range tr.Behaviors {
-				if _, exists := fr.Behaviors[key]; !exists {
-					b.DiffAdded = true
-					abs.Behaviors[key] = b
+			for _, tb := range tr.Behaviors {
+				found := false
+				for _, fb := range fr.Behaviors {
+					if len(fr.Behaviors) > 0 && fb.Evidence == tb.Evidence {
+						found = true
+						break
+					}
+				}
+				if !found {
+					tb.DiffAdded = true
+					abs.Behaviors = append(abs.Behaviors, tb)
 				}
 			}
 
 			// if source behavior is not in the destination
-			for key, b := range fr.Behaviors {
-				if _, exists := tr.Behaviors[key]; !exists {
-					b.DiffRemoved = true
-					abs.Behaviors[key] = b
+			for _, fb := range fr.Behaviors {
+				found := false
+				for _, tb := range tr.Behaviors {
+					if len(fr.Behaviors) > 0 && tb.Evidence == fb.Evidence {
+						found = true
+						break
+					}
+				}
+				if !found {
+					fb.DiffRemoved = true
+					abs.Behaviors = append(abs.Behaviors, fb)
 				}
 			}
 

--- a/pkg/bincapz/bincapz.go
+++ b/pkg/bincapz/bincapz.go
@@ -21,20 +21,24 @@ type Behavior struct {
 
 	DiffAdded   bool `json:",omitempty" yaml:",omitempty"`
 	DiffRemoved bool `json:",omitempty" yaml:",omitempty"`
+
+	// Fields for more compliant JSON output
+	// Evidence is the original map key from map[string]*Behavior
+	Evidence string `json:",omitempty" yaml:",omitempty"`
 }
 
 type FileReport struct {
 	Path   string
 	SHA256 string
 	// compiler -> x
-	Error             string               `json:",omitempty" yaml:",omitempty"`
-	Skipped           string               `json:",omitempty" yaml:",omitempty"`
-	Meta              map[string]string    `json:",omitempty" yaml:",omitempty"`
-	Syscalls          []string             `json:",omitempty" yaml:",omitempty"`
-	Pledge            []string             `json:",omitempty" yaml:",omitempty"`
-	Capabilities      []string             `json:",omitempty" yaml:",omitempty"`
-	Behaviors         map[string]*Behavior `json:",omitempty" yaml:",omitempty"`
-	FilteredBehaviors int                  `json:",omitempty" yaml:",omitempty"`
+	Error             string            `json:",omitempty" yaml:",omitempty"`
+	Skipped           string            `json:",omitempty" yaml:",omitempty"`
+	Meta              map[string]string `json:",omitempty" yaml:",omitempty"`
+	Syscalls          []string          `json:",omitempty" yaml:",omitempty"`
+	Pledge            []string          `json:",omitempty" yaml:",omitempty"`
+	Capabilities      []string          `json:",omitempty" yaml:",omitempty"`
+	Behaviors         []*Behavior       `json:",omitempty" yaml:",omitempty"`
+	FilteredBehaviors int               `json:",omitempty" yaml:",omitempty"`
 
 	// The relative path we think this moved from.
 	PreviousRelPath string `json:",omitempty" yaml:",omitempty"`

--- a/pkg/render/markdown.go
+++ b/pkg/render/markdown.go
@@ -118,8 +118,8 @@ func markdownTable(_ context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 	}
 
 	kbs := []KeyedBehavior{}
-	for k, b := range fr.Behaviors {
-		kbs = append(kbs, KeyedBehavior{Key: k, Behavior: b})
+	for _, b := range fr.Behaviors {
+		kbs = append(kbs, KeyedBehavior{Key: b.Evidence, Behavior: b})
 	}
 
 	if len(kbs) == 0 {

--- a/pkg/render/simple.go
+++ b/pkg/render/simple.go
@@ -27,14 +27,18 @@ func (r Simple) File(_ context.Context, fr *bincapz.FileReport) error {
 
 	fmt.Fprintf(r.w, "# %s\n", fr.Path)
 
-	bs := []string{}
+	bs := []*bincapz.Behavior{}
 
-	for k := range fr.Behaviors {
-		bs = append(bs, k)
+	for _, b := range fr.Behaviors {
+		bs = append(bs, b)
 	}
-	sort.Strings(bs)
+
+	sort.Slice(bs, func(i, j int) bool {
+		return bs[i].Evidence < bs[j].Evidence
+	})
+
 	for _, k := range bs {
-		fmt.Fprintf(r.w, "%s\n", k)
+		fmt.Fprintf(r.w, "%s\n", k.Evidence)
 	}
 	return nil
 }
@@ -47,27 +51,31 @@ func (r Simple) Full(_ context.Context, rep *bincapz.Report) error {
 	for f, fr := range rep.Diff.Removed {
 		fmt.Fprintf(r.w, "--- missing: %s\n", f)
 
-		bs := []string{}
-		for k := range fr.Behaviors {
-			bs = append(bs, k)
+		bs := []*bincapz.Behavior{}
+		for _, b := range fr.Behaviors {
+			bs = append(bs, b)
 		}
-		sort.Strings(bs)
+		sort.Slice(bs, func(i, j int) bool {
+			return bs[i].Evidence < bs[j].Evidence
+		})
 
 		for _, k := range bs {
-			fmt.Fprintf(r.w, "-%s\n", k)
+			fmt.Fprintf(r.w, "-%s\n", k.Evidence)
 		}
 	}
 
 	for f, fr := range rep.Diff.Removed {
 		fmt.Fprintf(r.w, "++++ added: %s\n", f)
-		bs := []string{}
-		for k := range fr.Behaviors {
-			bs = append(bs, k)
+		bs := []*bincapz.Behavior{}
+		for _, b := range fr.Behaviors {
+			bs = append(bs, b)
 		}
-		sort.Strings(bs)
+		sort.Slice(bs, func(i, j int) bool {
+			return bs[i].Evidence < bs[j].Evidence
+		})
 
 		for _, k := range bs {
-			fmt.Fprintf(r.w, "+%s\n", k)
+			fmt.Fprintf(r.w, "+%s\n", k.Evidence)
 		}
 	}
 
@@ -77,20 +85,22 @@ func (r Simple) Full(_ context.Context, rep *bincapz.Report) error {
 		} else {
 			fmt.Fprintf(r.w, "*** changed: %s\n", fr.Path)
 		}
-		bs := []string{}
-		for k := range fr.Behaviors {
-			bs = append(bs, k)
+		bs := []*bincapz.Behavior{}
+		for _, b := range fr.Behaviors {
+			bs = append(bs, b)
 		}
-		sort.Strings(bs)
+		sort.Slice(bs, func(i, j int) bool {
+			return bs[i].Evidence < bs[j].Evidence
+		})
 
-		for _, k := range bs {
-			b := fr.Behaviors[k]
+		for i := range bs {
+			b := bs[i]
 			if b.DiffRemoved {
-				fmt.Fprintf(r.w, "-%s\n", k)
+				fmt.Fprintf(r.w, "-%s\n", b.Evidence)
 				continue
 			}
 			if b.DiffAdded {
-				fmt.Fprintf(r.w, "+%s\n", k)
+				fmt.Fprintf(r.w, "+%s\n", b.Evidence)
 			}
 		}
 	}

--- a/pkg/render/stats.go
+++ b/pkg/render/stats.go
@@ -54,9 +54,9 @@ func pkgStatistics(files map[string]*bincapz.FileReport) ([]bincapz.StrMetric, i
 	pkgMap := make(map[string]int)
 	pkg := make(map[string]float64)
 	for _, rf := range files {
-		for namespace := range rf.Behaviors {
+		for _, namespace := range rf.Behaviors {
 			numNamespaces++
-			pkgMap[namespace]++
+			pkgMap[namespace.Evidence]++
 		}
 	}
 	for namespace, count := range pkgMap {

--- a/pkg/render/terminal.go
+++ b/pkg/render/terminal.go
@@ -198,8 +198,8 @@ func renderTable(ctx context.Context, fr *bincapz.FileReport, w io.Writer, rc ta
 	}
 
 	kbs := []KeyedBehavior{}
-	for k, b := range fr.Behaviors {
-		kbs = append(kbs, KeyedBehavior{Key: k, Behavior: b})
+	for _, b := range fr.Behaviors {
+		kbs = append(kbs, KeyedBehavior{Key: b.Evidence, Behavior: b})
 	}
 
 	if len(kbs) == 0 {

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -287,7 +287,7 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, ignoreTags 
 		Path:      path,
 		SHA256:    ptCheck,
 		Meta:      map[string]string{},
-		Behaviors: map[string]*bincapz.Behavior{},
+		Behaviors: []*bincapz.Behavior{},
 	}
 
 	pledges := []string{}
@@ -311,9 +311,10 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, ignoreTags 
 		ruleURL := generateRuleURL(m.Namespace, m.Rule)
 
 		b := &bincapz.Behavior{
-			RiskScore:    risk,
-			RiskLevel:    RiskLevels[risk],
+			Evidence:     key,
 			MatchStrings: matchStrings(m.Rule, m.Strings),
+			RiskLevel:    RiskLevels[risk],
+			RiskScore:    risk,
 			RuleURL:      ruleURL,
 		}
 
@@ -393,16 +394,24 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, ignoreTags 
 			b.Description = strings.ReplaceAll(m.Rule, "_", " ")
 		}
 
-		existing, exists := fr.Behaviors[key]
-		// If we have matched a lower priority rule in the same namespace, replace it
-		if !exists || existing.RiskScore < b.RiskScore {
-			fr.Behaviors[key] = b
-			continue
+		existingIndex := -1
+		for i, existing := range fr.Behaviors {
+			if existing.Evidence == key {
+				existingIndex = i
+				break
+			}
 		}
 
 		// If the existing description is longer and the priority is the same or lower
-		if len(existing.Description) < len(b.Description) && existing.RiskScore <= b.RiskScore {
-			fr.Behaviors[key].Description = b.Description
+		if existingIndex != -1 {
+			if fr.Behaviors[existingIndex].RiskScore < b.RiskScore {
+				fr.Behaviors = append(fr.Behaviors[:existingIndex], append([]*bincapz.Behavior{b}, fr.Behaviors[existingIndex+1:]...)...)
+			}
+			if len(fr.Behaviors[existingIndex].Description) < len(b.Description) && fr.Behaviors[existingIndex].RiskScore <= b.RiskScore {
+				fr.Behaviors[existingIndex].Description = b.Description
+			}
+		} else {
+			fr.Behaviors = append(fr.Behaviors, b)
 		}
 
 		// TODO: If we match multiple rules within a single namespace, merge matchstrings

--- a/samples/macOS/clean/ls.json
+++ b/samples/macOS/clean/ls.json
@@ -15,8 +15,8 @@
             "Pledge": [
                 "rpath"
             ],
-            "Behaviors": {
-                "env/TERM": {
+            "Behaviors": [
+                {
                     "Description": "Look up or override terminal settings",
                     "MatchStrings": [
                         "TERM"
@@ -24,9 +24,10 @@
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/env/TERM.yara#TERM",
-                    "ReferenceURL": "https://www.gnu.org/software/gettext/manual/html_node/The-TERM-variable.html"
+                    "ReferenceURL": "https://www.gnu.org/software/gettext/manual/html_node/The-TERM-variable.html",
+                    "Evidence": "env/TERM"
                 },
-                "fs/directory/traverse": {
+                {
                     "Description": "traverse filesystem hierarchy",
                     "MatchStrings": [
                         "_fts_children",
@@ -37,9 +38,10 @@
                     ],
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
-                    "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/fs/directory-traverse.yara#fts"
+                    "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/fs/directory-traverse.yara#fts",
+                    "Evidence": "fs/directory/traverse"
                 },
-                "fs/link/read": {
+                {
                     "Description": "read value of a symbolic link",
                     "MatchStrings": [
                         "readlink"
@@ -47,9 +49,10 @@
                     "RiskScore": 1,
                     "RiskLevel": "LOW",
                     "RuleURL": "https://github.com/chainguard-dev/bincapz/blob/main/rules/fs/link-read.yara#readlink",
-                    "ReferenceURL": "https://man7.org/linux/man-pages/man2/readlink.2.html"
+                    "ReferenceURL": "https://man7.org/linux/man-pages/man2/readlink.2.html",
+                    "Evidence": "fs/link/read"
                 }
-            },
+            ],
             "RiskScore": 1,
             "RiskLevel": "LOW"
         }

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -82,7 +82,7 @@ func TestJSON(t *testing.T) {
 
 			got := out.String()
 			if diff := cmp.Diff(want, got); diff != "" {
-				t.Errorf("markdown output mismatch: (-want +got):\n%s", diff)
+				t.Errorf("json output mismatch: (-want +got):\n%s", diff)
 			}
 		})
 		return nil


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/208

This PR replaces the original `map[string]*Behavior` with `[]*Behavior`. 

Moving from maps to slices complicates things a bit but mainly around not being able to rely on the `key`. To work around this, I added a new `Evidence` field to the `Behavior` struct to store the key which handles all of the previous key operations.

And the good news is: `make test` runs cleanly with these changes:
```
PASS
ok  	github.com/chainguard-dev/bincapz/samples	16.336s
```