### PR TITLE
Ignore empty root strings when choosing output format

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -93,7 +93,7 @@ func scanSinglePath(ctx context.Context, c Config, yrs *yara.Rules, path string,
 
 	// If absPath is provided, use it instead of the path if they are different.
 	// This is useful when scanning images and archives.
-	if absPath != "" && absPath != path {
+	if absPath != "" && absPath != path && root != "" {
 		fr.Path = fmt.Sprintf("%s ∴ %s", absPath, formatPath(cleanPath(path, root)))
 	}
 


### PR DESCRIPTION
Quick fix for #217. 

If the `root` string is empty, we'll output something like:
```
/Users/egibs/repos/os/zstd.yaml ∴ Users/egibs/repos/os/zstd.yaml
```
which is definitely not desired.

This PR fixes that by ignoring cases where `root` is empty (i.e. when scanning non-archives/images):
```
/Users/egibs/repos/os/zstd.yaml [✅ LOW]
----------------------------------------------------------------------------------------------------------------------------------
RISK  KEY                  DESCRIPTION                                      EVIDENCE
----------------------------------------------------------------------------------------------------------------------------------
NONE  ref/path/usr         path reference within /usr/                      /usr/lib/libzstd.so.
LOW   compression/zstd     Zstandard: fast real-time compression algorithm  zstd
LOW   fs/directory/create  creates directories                              mkdir
LOW   kernel/cpu/info      gets number of processors                        nproc
LOW   ref/site/url         contains embedded HTTPS URLs                     https://github.com/facebook/zstd/archive/refs/tags/v
----------------------------------------------------------------------------------------------------------------------------------
```