### PR TITLE
Recursive: return first YARA parse error instead of last

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -61,41 +61,28 @@ func Recursive(ctx context.Context, fss []fs.FS) (*yara.Rules, error) {
 		return nil, fmt.Errorf("yara compiler: %w", err)
 	}
 
-	addErrs := []error{}
 	for _, root := range fss {
 		err = fs.WalkDir(root, ".", func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
 
-			logger := clog.FromContext(ctx).With("path", path)
 			if !d.IsDir() && (filepath.Ext(path) == ".yara" || filepath.Ext(path) == ".yar") {
 				bs, err := fs.ReadFile(root, path)
 				if err != nil {
 					return fmt.Errorf("readfile: %w", err)
 				}
 
-				// Our Yara library panics a lot
-				defer func() {
-					if err := recover(); err != nil {
-						logger.Error("recovered from panic", slog.Any("error", err))
-					}
-				}()
-
 				if err := yc.AddString(string(bs), path); err != nil {
-					err = fmt.Errorf("yara addfile %s: %w", path, err)
-					addErrs = append(addErrs, err)
-					return err
+					return fmt.Errorf("failed to parse %s: %v", path, err)
 				}
 			}
 
 			return nil
 		})
-	}
-
-	if len(addErrs) > 0 {
-		// Normally I would use errors.Join, but only the first error is useful in go-yara
-		return nil, addErrs[0]
+		if err != nil {
+			break
+		}
 	}
 
 	if err != nil {


### PR DESCRIPTION
Due to how the `Recursive()` YARA compiler function was organized, it would continue to parse YARA files after the error, resulting in panics or the baffling error message:

`yara-rules-full.yar: Compiler cannot be used after parse error"`

This now returns the first error encountered, for example:

`failed to parse ref/words/ssh_attack.yara:  duplicated string identifier \"$ref2\"`

With any luck, we won't need the panic handler any longer, so it's been removed.
