### PR TITLE
Release/Tag Workflow followup fixes

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -24,18 +24,20 @@ jobs:
     - name: Get Version
       id: get-version
       run: |
-        CURRENT_VERSION=$(awk -F'"' '/ID string =/ {print $2}' ${{ env.VERSION_FILE }})
-        echo "VERSION=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"
+        VERSION=$(awk -F'"' '/ID string =/ {print $2}' ${{ env.VERSION_FILE }})
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Create Tag
       if: ${{ steps.get-version.outputs.VERSION != '' }}
       run: |
-        if [ $(git tag -l "${{ steps.get-version.outputs.VERSION }}") ]; then
-            echo "Tag already exists for version $CURRENT_VERSION"
+        VERSION=${{ steps.get-version.outputs.VERSION }}
+        if [ $(git tag -l "$VERSION") ]; then
+            echo "Tag already exists for version $VERSION"
             exit 0
         else
+          git config --global tag.gpgsign true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag $CURRENT_VERSION
-          git push --tags
+          git tag $VERSION
+          git push origin tag $VERSION
           gitsign verify $(git rev-list --tags --max-count=1) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
         fi

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -47,16 +47,20 @@ jobs:
             exit 1
             ;;
         esac
+
+        echo "Current bincapz version: $CURRENT_VERSION"
+        echo "New bincapz version: $VERSION"
         
-        sed -i'' -e "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
+        sed -i -e "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
     - name: Commit Version Update
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git checkout -b bincapz-version-bump-$VERSION
+        BRANCH="bincapz-version-bump-$VERSION"
+        git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump bincapz version to v$VERSION"
-        git push origin bincapz-bump-version-$VERSION
+        git push origin $BRANCH
         gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request
       run: |


### PR DESCRIPTION
This PR makes a few tweaks/additions:
1. Uses `sed -i` instead of `sed -i''` (MacOS testing artifact)
2. Adds version output to the version bump Workflow for quick verification; uses a branch variable (I typo'd the branch name inadvertently which broke the push)
3. Uses better (and correct) variables for the tag Workflow
4. Uses GPG signing for tags (which will be needed for `gitsign`)
5. Pushes the newly-created tag rather than all tags

Original errors:
![CleanShot 2024-06-09 at 17 30 57@2x](https://github.com/chainguard-dev/bincapz/assets/20933572/7aa39c6b-78aa-42a2-9258-b9d1493d581c)
![CleanShot 2024-06-09 at 17 31 19@2x](https://github.com/chainguard-dev/bincapz/assets/20933572/6bb30465-02e1-420a-827f-fbdafd4a2d52)