### PR TITLE
Annotate tag and add message

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -30,7 +30,8 @@ jobs:
       if: ${{ steps.get-version.outputs.VERSION != '' }}
       run: |
         VERSION=${{ steps.get-version.outputs.VERSION }}
-        if [ $(git tag -l "$VERSION") ]; then
+
+        if git rev-parse "refs/tags/$VERSION" >/dev/null 2>&1; then
             echo "Tag already exists for version $VERSION"
             exit 0
         else

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -37,7 +37,7 @@ jobs:
           git config --global tag.gpgsign true
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag $VERSION
+          git tag -a $VERSION -m "Tagging version $VERSION"
           git push origin tag $VERSION
           gitsign verify $(git rev-list --tags --max-count=1) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
         fi

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -63,5 +63,7 @@ jobs:
         git push origin $BRANCH
         gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create -t "Update bincapz to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
     - name: Update Version
+      id: update
       run: |
         UPDATE_TYPE=${{ github.event.inputs.update }}
 
@@ -52,10 +53,12 @@ jobs:
         echo "New bincapz version: $VERSION"
         
         sed -i -e "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Commit Version Update
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        VERSION=${{ steps.update.outputs.VERSION }}
         BRANCH="bincapz-version-bump-$VERSION"
         git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}


### PR DESCRIPTION
We need to add a tagging message when creating tags, otherwise the Workflow will fail since it will try to open an editor for the message.

I also added -a to create an annotated tag rather than a lightweight tag.

Before this merges I also want to fix the tag checking since the Workflow tried to create the v0.12.0 tag even though it already exists as well as some version Workflow bugs.