### PR TITLE
Create release instead of Tag; other fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,9 +1,7 @@
-name: Tag Release
+name: Cut Release
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   id-token: write
@@ -26,18 +24,14 @@ jobs:
       run: |
         VERSION=$(awk -F'"' '/ID string =/ {print $2}' ${{ env.VERSION_FILE }})
         echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-    - name: Create Tag
+    - name: Create Release
+      env:
+        GH_TOKEN: ${{ github.token }}
       if: ${{ steps.get-version.outputs.VERSION != '' }}
       run: |
         VERSION=${{ steps.get-version.outputs.VERSION }}
-        if [ $(git tag -l "$VERSION") ]; then
-            echo "Tag already exists for version $VERSION"
-            exit 0
-        else
-          git config --global tag.gpgsign true
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag $VERSION
-          git push origin tag $VERSION
-          gitsign verify $(git rev-list --tags --max-count=1) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
-        fi
+        git config --global tag.gpgsign true
+        git config user.name "github-actions[bot]"
+        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        gh release create "$VERSION" --title "$VERSION" --notes "Release $VERSION" --draft --generate-notes
+        gitsign verify $(git rev-list --tags --max-count=1) --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -65,7 +65,7 @@ jobs:
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump bincapz version to v$VERSION"
         git push origin $BRANCH
-        gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
+        gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request
       env:
         GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -25,6 +25,7 @@ jobs:
     - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
     - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
     - name: Update Version
+      id: update
       run: |
         UPDATE_TYPE=${{ github.event.inputs.update }}
 
@@ -52,10 +53,13 @@ jobs:
         echo "New bincapz version: $VERSION"
         
         sed -i -e "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
+        
+        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Commit Version Update
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        VERSION=${{ steps.update.outputs.VERSION }}
         BRANCH="bincapz-version-bump-$VERSION"
         git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}
@@ -63,5 +67,7 @@ jobs:
         git push origin $BRANCH
         gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request
+      env:
+        GH_TOKEN: ${{ github.token }}
       run: |
         gh pr create -t "Update bincapz to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main


### PR DESCRIPTION
We can automate tag creation via `gh release create` which is a more common practice than specifically creating a tag from `main` and then creating a release after the fact.

This PR replaces the tag creation Workflow with a release creation Workflow that will run via `workflow_dispatch` and create a draft Release that can be reviewed prior to publishing. This will allow us to control the timing of releases but still automate the tedious parts.

This PR also adds cross-step variables for the version bump Workflow so that we can actually access the correct version information (though the core version logic is working):
![CleanShot 2024-06-10 at 07 13 22@2x](https://github.com/chainguard-dev/bincapz/assets/20933572/ab920868-30d2-46da-bacd-10044adbcb5d)
and also updates the `certificate-identity-regexp` to include a trailing `/*` so we match subjects appropriately.