### PR TITLE
Add pull-requests: write to version bump Workflow

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -9,8 +9,9 @@ on:
         default: 'minor'
 
 permissions:
-  id-token: write
   contents: write
+  id-token: write
+  pull-requests: write
 
 env:
   VERSION_FILE: pkg/version/version.go


### PR DESCRIPTION
Hopefully the last Workflow tweak needed -- creating PRs is under different scope than other repository contents.

Reference:
https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token

`contents: write` will be valid for creating releases so that Workflow should be okay.