### PR TITLE
Add --err-first-(hit|miss) flags

### DIFF
--- a/bincapz.go
+++ b/bincapz.go
@@ -65,6 +65,8 @@ func main() {
 	minLevelFlag := flag.Int("min-level", -1, "Obsoleted by --min-risk")
 	minFileRiskFlag := flag.String("min-file-risk", "low", "Only show results for files that meet this risk level (any,low,medium,high,critical")
 	minRiskFlag := flag.String("min-risk", "low", "Minimum risk level to show results for (any,low,medium,high,critical)")
+	errFirstMissFlag := flag.Bool("err-first-miss", false, "exit with error if scan source has no matching capabilities")
+	errFirstHitFlag := flag.Bool("err-first-hit", false, "exit with error if scan source has matching capabilities")
 	ociFlag := flag.Bool("oci", false, "Scan an OCI image")
 	omitEmptyFlag := flag.Bool("omit-empty", false, "Omit files that contain no matches")
 	profileFlag := flag.Bool("profile", false, "Generate profile and trace files")
@@ -81,7 +83,7 @@ func main() {
 
 	logLevel := new(slog.LevelVar)
 	logLevel.Set(slog.LevelError)
-	logOpts := &slog.HandlerOptions{Level: logLevel}
+	logOpts := &slog.HandlerOptions{Level: logLevel, AddSource: true}
 	log := clog.New(slog.NewTextHandler(os.Stderr, logOpts))
 
 	var stop func()
@@ -187,6 +189,8 @@ func main() {
 		Rules:            yrs,
 		ScanPaths:        args,
 		Stats:            stats,
+		ErrFirstHit:      *errFirstHitFlag,
+		ErrFirstMiss:     *errFirstMissFlag,
 	}
 
 	var res *bincapz.Report
@@ -198,7 +202,7 @@ func main() {
 	}
 	if err != nil {
 		returnCode = ExitActionFailed
-		log.Error("action failed", slog.Any("error", err))
+		fmt.Fprintf(os.Stderr, "%s\n", err)
 		return
 	}
 

--- a/pkg/action/action.go
+++ b/pkg/action/action.go
@@ -23,4 +23,6 @@ type Config struct {
 	Rules            *yara.Rules
 	ScanPaths        []string
 	Stats            bool
+	ErrFirstMiss     bool
+	ErrFirstHit      bool
 }

--- a/pkg/action/programkind.go
+++ b/pkg/action/programkind.go
@@ -48,6 +48,7 @@ var extMap = map[string]string{
 	".java":    "Java source",
 	".js":      "Javascript",
 	".json":    "",
+	".md":      "",
 	".php":     "PHP file",
 	".pl":      "PERL script",
 	".py":      "Python script",

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -187,7 +187,7 @@ func recursiveScan(ctx context.Context, c Config) (*bincapz.Report, error) {
 		}
 		logger.Debug("files found", slog.Any("path count", len(paths)), slog.Any("scanPath", scanPath))
 
-		// path refersll to a real local path, not a virtual scan path
+		// path refers to a real local path, not the requested scanPath
 		for _, path := range paths {
 			if isSupportedArchive(path) {
 				logger.Debug("found archive path", slog.Any("path", path))
@@ -322,7 +322,7 @@ func processFile(ctx context.Context, c Config, yrs *yara.Rules, path string, sc
 	return fr, nil
 }
 
-// Scan is the public API forYARA scanning a data source, applying filters if necessary.
+// Scan YARA scans a data source, applying output filters if necessary.
 func Scan(ctx context.Context, c Config) (*bincapz.Report, error) {
 	r, err := recursiveScan(ctx, c)
 	if err != nil {


### PR DESCRIPTION
This flag is intended to streamline rule optimization for false-positives/false-negatives.

* If you point bincapz at a malware repository, you can now use `--err-first-miss` to error if anything doesn't match.
* If you point bincapz at a known-clean directory, you can now use `--err-first-hit` to error if something matches

This has been tested with archive files and OCI images. The intended behavior is that it should consider the entirety of an archive or image before exiting early for a miss.

After revisiting it for the first time in a couple of months, I found some of the file-scanning code difficult to follow, so I made it more verbose. I also fixed a bug where if the path given was a symlink, bincapz wouldn't follow it.





