### PR TITLE
Add rule for CVE-2024-4577

### DIFF
--- a/rules/combo/backdoor/php.yara
+++ b/rules/combo/backdoor/php.yara
@@ -277,3 +277,20 @@ rule php_str_replace_obfuscation : critical {
 	condition:
 		filesize < 65535 and 2 of ($f*) and any of ($i*) and 2 of ($o*)
 }
+
+rule php_cgi_argument_injection : critical {
+  meta:
+    date = "2024-06-06"
+    description = "detect php CGI argument injections"
+    discovered_by = "Orange Tsai (@orange_8361) of DEVCORE (@d3vc0r3)"
+    exploiters = "Aliz (@AlizTheHax0r) and Sina Kheirkhah (@SinSinology) of watchTowr (@watchtowrcyber)"
+    reference = "https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en"
+    repository = "https://github.com/watchtowrlabs/CVE-2024-4577"
+    technical = "https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577"
+
+  strings:
+    $url_pattern = /\?%ADd\+allow_url_include%3d1\+(%ADd|-)[d+]\+auto_prepend_file%3dphp:\/\/input/ nocase
+
+  condition:
+    $url_pattern
+}

--- a/rules/combo/backdoor/php.yara
+++ b/rules/combo/backdoor/php.yara
@@ -277,20 +277,3 @@ rule php_str_replace_obfuscation : critical {
 	condition:
 		filesize < 65535 and 2 of ($f*) and any of ($i*) and 2 of ($o*)
 }
-
-rule php_cgi_argument_injection : critical {
-  meta:
-    date = "2024-06-06"
-    description = "detect php CGI argument injections"
-    discovered_by = "Orange Tsai (@orange_8361) of DEVCORE (@d3vc0r3)"
-    exploiters = "Aliz (@AlizTheHax0r) and Sina Kheirkhah (@SinSinology) of watchTowr (@watchtowrcyber)"
-    reference = "https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en"
-    repository = "https://github.com/watchtowrlabs/CVE-2024-4577"
-    technical = "https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577"
-
-  strings:
-    $url_pattern = /\?%ADd\+allow_url_include%3d1\+(%ADd|-)[d+]\+auto_prepend_file%3dphp:\/\/input/ nocase
-
-  condition:
-    $url_pattern
-}

--- a/rules/explots/php/cve-2024-4577.yara
+++ b/rules/explots/php/cve-2024-4577.yara
@@ -1,0 +1,16 @@
+rule php_cgi_argument_injection : critical {
+  meta:
+    date = "2024-06-06"
+    description = "detect php CGI argument injections"
+    discovered_by = "Orange Tsai (@orange_8361) of DEVCORE (@d3vc0r3)"
+    exploiters = "Aliz (@AlizTheHax0r) and Sina Kheirkhah (@SinSinology) of watchTowr (@watchtowrcyber)"
+    reference = "https://devco.re/blog/2024/06/06/security-alert-cve-2024-4577-php-cgi-argument-injection-vulnerability-en"
+    repository = "https://github.com/watchtowrlabs/CVE-2024-4577"
+    technical = "https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577"
+
+  strings:
+    $url_pattern = /\?%ADd\+allow_url_include%3d1\+(%ADd|-)[d+]\+auto_prepend_file%3dphp:\/\/input/
+
+  condition:
+    $url_pattern
+}


### PR DESCRIPTION
This PR is an attempt to detect the conditions for `CVE-2024-4577` --
- https://www.wiz.io/blog/critical-rce-php-cgi-vulnerability
- https://github.com/watchtowrlabs/CVE-2024-4577
- https://labs.watchtowr.com/no-way-php-strikes-again-cve-2024-4577
- https://pentesterlab.com/exercises/cve-2012-1823

This will match the specific POC request which matches this from the `pentesterlab` post for `CVE-2012-1823`:
![CleanShot 2024-06-10 at 14 38 34@2x](https://github.com/chainguard-dev/bincapz/assets/20933572/652a63a0-bb5d-4698-b374-700ebc80c2cb)

`allow_url_include` and `auto_prepend_file` were covered in the Dodgy PHP rules (separately), but I didn't see a soft-hyphen rule unless searching failed me.