### PR TITLE
Fix version check in verson.yaml Workflow

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -42,13 +42,13 @@ jobs:
         
         case "$UPDATE_TYPE" in
           major)
-            VERSION=$(printf "%d.0.0" $((${VERSION_PARTS[0]}+1)))
+            VERSION=$(printf "v%d.0.0" $((${VERSION_PARTS[0]}+1)))
             ;;
           minor)
-            VERSION=$(printf "%s.%d.0" ${VERSION_PARTS[0]} $((${VERSION_PARTS[1]}+1)))
+            VERSION=$(printf "v%s.%d.0" ${VERSION_PARTS[0]} $((${VERSION_PARTS[1]}+1)))
             ;;
           patch)
-            VERSION=$(printf "%s.%s.%d" ${VERSION_PARTS[0]} ${VERSION_PARTS[1]} $((${VERSION_PARTS[2]}+1)))
+            VERSION=$(printf "v%s.%s.%d" ${VERSION_PARTS[0]} ${VERSION_PARTS[1]} $((${VERSION_PARTS[2]}+1)))
             ;;
           *)
             echo "Error: Invalid update type"
@@ -64,7 +64,7 @@ jobs:
         echo "Current bincapz version: $CURRENT_VERSION"
         echo "New bincapz version: $VERSION"
         
-        sed -i -e "s/ID string = \"v[0-9]+\.[0-9]+\.[0-9]+\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
+        sed -i -e "s/ID string = \"v[0-9]+\.[0-9]+\.[0-9]+\"/ID string = \"$VERSION\"/" ${{ env.VERSION_FILE }}
         
         echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Commit Version Update
@@ -75,7 +75,7 @@ jobs:
         BRANCH="bincapz-version-bump-$VERSION"
         git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}
-        git commit -m "Bump bincapz version to v$VERSION"
+        git commit -m "Bump bincapz version to $VERSION"
         git push origin $BRANCH
         gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -77,7 +77,6 @@ jobs:
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump bincapz version to $VERSION"
         git push origin $BRANCH
-        gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
     - name: Create Pull Request
       env:
         GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
We were validating the updated version string against a regex expression that expected the string to be prefixed with `v` when we only update the actual semver.

This PR removes adds the `v` prefix to the `printf` statements in `version.yaml` to fix [this](https://github.com/chainguard-dev/bincapz/actions/runs/9627113069/job/26553832141) failure:
```
Error: VERSION is not a valid semver
```

and removes the `v` from the version string in this line (original code shown):
```sh
sed -i -e "s/ID string = \"v[0-9]+\.[0-9]+\.[0-9]+\"/ID string = \"v$VERSION\"/" ${{ env.VERSION_FILE }}
```

I tested this locally and it fixed the issue --

Fixed code:
```sh
❯ ./test.sh patch
Current bincapz version: v0.13.1
New bincapz version: v0.13.2
```

Original code:
```sh
❯ ./test.sh patch
v0.13.1
Error: 0.13.2 is not a valid semver
```