### PR TITLE
Consolidate version update steps

### DIFF
--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -64,21 +64,20 @@ jobs:
         echo "Current bincapz version: $CURRENT_VERSION"
         echo "New bincapz version: $VERSION"
         
-        sed -i -e "s/ID string = \"v[0-9]+\.[0-9]+\.[0-9]+\"/ID string = \"$VERSION\"/" ${{ env.VERSION_FILE }}
+        sed -i "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"${VERSION}\"/" ${{ env.VERSION_FILE }}
         
-        echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
-    - name: Commit Version Update
-      run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        VERSION=${{ steps.update.outputs.VERSION }}
         BRANCH="bincapz-version-bump-$VERSION"
         git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}
         git commit -m "Bump bincapz version to $VERSION"
         git push origin $BRANCH
+
+        echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       env:
         GH_TOKEN: ${{ github.token }}
       run: |
+        VERSION=${{ steps.update.outputs.VERSION }}
         gh pr create -t "Update bincapz to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main


### PR DESCRIPTION
This PR fixes the version update `sed` command and consolidates the version update Steps (update + committing) into a single Step.

I also passed the version to the PR creation Step so that the PR actually contains the value.

I tested the updated Workflow in my fork (ignoring the multiple commits since I ran the Workflow from a feature branch with un-merged changes): https://github.com/egibs/bincapz/pull/4