### PR TITLE
Remove Kiteshield false negatives

### DIFF
--- a/rules/evasion/packer/kiteshield.yara
+++ b/rules/evasion/packer/kiteshield.yara
@@ -1,21 +1,13 @@
-import "elf"
-
 rule kiteshield : high {
   meta:
     author = "Alex.Turing, Wang Hao"
     date = "2024-05-28"
     description = "Rule to identify files packed by Kiteshield"
-    hash_amdc6766_1 = "4d79e1a1027e7713180102014fcfb3bf"
-    hash_amdc6766_2 = "2c80808b38140f857dc8b2b106764dd8"
-    hash_amdc6766_3 = "a42249e86867526c09d78c79ae26191d"
-    hash_amdc6766_4 = "909c015d5602513a770508fa0b87bc6f"
-    hash_amdc6766_5 = "57f7ffaa0333245f74e4ab68d708e14e"
-    hash_amdc6766_6 = "5ea33d0655cb5797183746c6a46df2e9"
-    hash_amdc6766_7 = "7671585e770cf0c856b79855e6bdca2a"
-    hash_gafgyt_1 = "4afedf6fbf4ba95bbecc865d45479eaf"
-    hash_gafgyt_2 = "5c9887c51a0f633e3d2af54f788da525"
-    hash_winnti_1 = "f5623e4753f4742d388276eaee72dea6"
-    hash_winnti_2 = "951fe6ce076aab5ca94da020a14a8e1c"
+    hash_amdc6766_1 = "2c80808b38140f857dc8b2b106764dd8"
+    hash_amdc6766_2 = "909c015d5602513a770508fa0b87bc6f"
+    hash_amdc6766_3 = "5ea33d0655cb5797183746c6a46df2e9"
+    hash_gafgyt = "4afedf6fbf4ba95bbecc865d45479eaf"
+    hash_winnti = "f5623e4753f4742d388276eaee72dea6"
     reference = "https://blog.xlab.qianxin.com/kiteshield_packer_is_being_abused_by_linux_cyber_threat_actors"
     tool = "Kiteshield"
     tool_repository = "https://github.com/GunshipPenguin/kiteshield"
@@ -38,16 +30,15 @@ rule kiteshield : high {
     $loader_s7 = {b3 b5 b7 b5 b3 bd bf bd b3 b5 ec ec ec f4 f4 f4}
 
   condition:
-    // $loader_jmp and all of ($loader_s*) and
-    // // ELF Magic at offset 0
-    // uint32(0) == 0x464c457f and
-    // // ET_EXEC at offset 16
-    // uint16(16) == 0x0002 and
-    // (
-    //     // x86_64 at offset 18
-    //     uint16(18) == 0x003e or
-    //     // aarch64 at offset 18
-    //     uint16(18) == 0x00b7
-    // )
-    $loader_jmp and all of ($loader_s*) and elf.type==elf.ET_EXEC and elf.machine == elf.EM_X86_64
+    $loader_jmp and all of ($loader_s*) and
+    // ELF Magic at offset 0
+    uint32(0) == 0x464c457f and
+    // ET_EXEC at offset 16
+    uint16(16) == 0x0002 and
+    (
+        // x86_64 at offset 18
+        uint16(18) == 0x003e or
+        // aarch64 at offset 18
+        uint16(18) == 0x00b7
+    )
 }

--- a/rules/evasion/packer/kiteshield.yara
+++ b/rules/evasion/packer/kiteshield.yara
@@ -1,3 +1,5 @@
+import "elf"
+
 rule kiteshield : high {
   meta:
     author = "Alex.Turing, Wang Hao"
@@ -36,15 +38,16 @@ rule kiteshield : high {
     $loader_s7 = {b3 b5 b7 b5 b3 bd bf bd b3 b5 ec ec ec f4 f4 f4}
 
   condition:
-    $loader_jmp and all of ($loader_s*) and
-    // ELF Magic at offset 0
-    uint32(0) == 0x464c457f and
-    // ET_EXEC at offset 16
-    uint16(16) == 0x0002 and
-    (
-        // x86_64 at offset 18
-        uint16(18) == 0x003e or
-        // aarch64 at offset 18
-        uint16(18) == 0x00b7
-    )
+    // $loader_jmp and all of ($loader_s*) and
+    // // ELF Magic at offset 0
+    // uint32(0) == 0x464c457f and
+    // // ET_EXEC at offset 16
+    // uint16(16) == 0x0002 and
+    // (
+    //     // x86_64 at offset 18
+    //     uint16(18) == 0x003e or
+    //     // aarch64 at offset 18
+    //     uint16(18) == 0x00b7
+    // )
+    $loader_jmp and all of ($loader_s*) and elf.type==elf.ET_EXEC and elf.machine == elf.EM_X86_64
 }


### PR DESCRIPTION
Relates to: #292

This PR removes the six MD5 hashes that appear as false negatives in Yara CI.

Even with the original rule logic documented in the reference blog post they show up as false negatives: https://github.com/egibs/bincapz/runs/26625762043

After removing these hashes, there are no more false negatives for the Kiteshield Rule: https://github.com/egibs/bincapz/runs/26625841070