### PR TITLE
Remove remaining false negatives

### DIFF
--- a/rules/archives/tar-command.yara
+++ b/rules/archives/tar-command.yara
@@ -3,8 +3,6 @@ rule executable_calls_archive_tool : high {
   meta:
     description = "command shells out to tar"
     hash_2023_0xShell_wesoori = "bab1040a9e569d7bf693ac907948a09323c5f7e7005012f7b75b5c1b2ced10ad"
-    hash_2023_AtomicStealer_Trading_View = "ce3c57e6c025911a916a61a716ff32f2699f3e3a84eb0ebbe892a5d4b8fb9c7a"
-    hash_2021_CDDS_UserAgent_v2019 = "9b71fad3280cf36501fe110e022845b29c1fb1343d5250769eada7c36bc45f70"
   strings:
     $a_tar_c = "tar -c"
     $a_tar_rX = "tar -r -X"

--- a/rules/security_controls/linux/iptables.yara
+++ b/rules/security_controls/linux/iptables.yara
@@ -44,9 +44,6 @@ rule iptables_delete : medium {
   meta:
     description = "deletes firewall rules"
     ref = "https://www.netfilter.org/projects/iptables/"
-    hash_2023_BPFDoor_8b84 = "8b84336e73c6a6d154e685d3729dfa4e08e4a3f136f0b2e7c6e5970df9145e95"
-    hash_2023_BPFDoor_8b9d = "8b9db0bc9152628bdacc32dab01590211bee9f27d58e0f66f6a1e26aea7552a6"
-    hash_2024_Downloads_e100 = "e100be934f676c64528b5e8a609c3fb5122b2db43b9aee3b2cf30052799a82da"
   strings:
     $ref = /iptables -X[\w]{0,16}/
   condition:

--- a/rules/security_controls/linux/iptables_delete.yara
+++ b/rules/security_controls/linux/iptables_delete.yara
@@ -4,9 +4,7 @@ rule iptables_delete : high {
     syscall = "posix_spawn"
     pledge = "exec"
     description = "Deletes rules from a iptables chain"
-    hash_2024_Unix_Downloader_Rocke_2f64 = "2f642efdf56b30c1909c44a65ec559e1643858aaea9d5f18926ee208ec6625ed"
     hash_2024_Unix_Downloader_Rocke_6107 = "61075056b46d001e2e08f7e5de3fb9bfa2aabf8fb948c41c62666fd4fab1040f"
-    hash_2023_Linux_Malware_Samples_0638 = "063830221431f8136766f2d740df6419c8cd2f73b10e07fa30067df506592210"
   strings:
     $ref = /iptables [\-\w% ]{0,8} -D[\-\w% ]{0,32}/
   condition:


### PR DESCRIPTION
Relates to: #292

As noted in [this](https://github.com/chainguard-dev/bincapz/issues/292#issuecomment-2188877729) comment, there are seven remaining false negative hashes.

This PR removes them. We should be able to verify this by looking at the CI run.

Update:
![CleanShot 2024-06-29 at 08 23 06@2x](https://github.com/chainguard-dev/bincapz/assets/20933572/87bc4215-9302-4711-b6fb-344ce5533660)

Report is clean (at least for non-matching files -- we still have [file] hashes that aren't in VirusTotal): https://github.com/egibs/bincapz/runs/26840395799