### PR TITLE
Turn off MALPEDIA_Win_Unidentified_107_Auto rule

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -20,7 +20,8 @@ var FS = rules.FS
 // badRules are noisy 3rd party rules to silently disable.
 var badRules = map[string]bool{
 	// YARAForge
-	"GODMODERULES_IDDQD_God_Mode_Rule": true,
+	"GODMODERULES_IDDQD_God_Mode_Rule":   true,
+	"MALPEDIA_Win_Unidentified_107_Auto": true,
 	// ThreatHunting Keywords (some duplicates)
 	"scp_greyware_tool_keyword":                  true,
 	"Antivirus_Signature_signature_keyword":      true,


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/284

This rule could probably be tweaked, but we don't currently have a way to selectively override third-party rules.

The rule for reference:
```yar
rule MALPEDIA_Win_Unidentified_107_Auto : FILE
{
	meta:
		description = "autogenerated rule brought to you by yara-signator"
		author = "Felix Bilstein - yara-signator at cocacoding dot com"
		id = "3e7e44ff-0f02-5267-8346-e5f949ff1ff2"
		date = "2023-12-06"
		modified = "2023-12-08"
		reference = "https://malpedia.caad.fkie.fraunhofer.de/details/win.unidentified_107"
		source_url = "https://github.com/malpedia/signator-rules//blob/fbacfc09b84d53d410385e66a8e56f25016c588a/rules/win.unidentified_107_auto.yar#L1-L117"
		license_url = "N/A"
		logic_hash = "36a3784a29d5434d0fa9e9c5acdfc21d8509c8e92eeaa689801f442b7fb11fdb"
		score = 75
		quality = 75
		tags = "FILE"
		version = "1"
		tool = "yara-signator v0.6.0"
		signator_config = "callsandjumps;datarefs;binvalue"
		malpedia_rule_date = "20231130"
		malpedia_hash = "fc8a0e9f343f6d6ded9e7df1a64dac0cc68d7351"
		malpedia_version = "20230808"
		malpedia_license = "CC BY-SA 4.0"
		malpedia_sharing = "TLP:WHITE"

	strings:
		$sequence_0 = { 4139d9 75d8 4c89e1 e8???????? }
		$sequence_1 = { 48897008 4c89e1 ff15???????? 488b05???????? 4c89e1 48891d???????? }
		$sequence_2 = { 0f83d6fdffff 4c8b35???????? 8b7304 448b2b 4883c308 4c01f6 44032e }
		$sequence_3 = { 034208 4839c1 7214 4883c228 }
		$sequence_4 = { 0f8584000000 4c8b3e 4929c7 4901cf }
		$sequence_5 = { e8???????? 4c89e1 ff15???????? 31c0 4883c428 }
		$sequence_6 = { 8b15???????? 85d2 0f8ea1feffff 488b35???????? 31db 4c8d65fc }
		$sequence_7 = { e8???????? 4989c7 48b9ca0e99c700000000 e8???????? 4883c464 488b4c2408 }
		$sequence_8 = { 4183fc01 0f85a9feffff 8b05???????? 85c0 0f8e9bfeffff 83e801 488b1d???????? }
		$sequence_9 = { 4c89442418 4c894c2420 4883ec64 48c7c10f15af3d }

	condition:
		7 of them and filesize <254976
}
```

Might be a case where `8 of them` would be sufficient if we're matching seven by default.