### PR TITLE
Resolve datadog-agent DDOS false positive

### DIFF
--- a/rules/net/ddos.yara
+++ b/rules/net/ddos.yara
@@ -9,7 +9,7 @@ rule ddos_refs : critical {
     $ref2 = "ackflood" fullword
     $ref3 = "synflood" fullword
     // datadog-agent tracer-fentry-debug.o
-    $ignore_ref = "defer_accept.synflood_warned.you"
+    $ignore_ref = /synflood\_\w+/
   condition:
     any of ($ref*) and not $ignore_ref
 }

--- a/rules/net/ddos.yara
+++ b/rules/net/ddos.yara
@@ -1,4 +1,3 @@
-
 rule ddos_refs : critical {
   meta:
     description = "Performs DDoS (distributed denial of service) attacks"
@@ -9,6 +8,8 @@ rule ddos_refs : critical {
     $ref = "TSource Engine Query"
     $ref2 = "ackflood" fullword
     $ref3 = "synflood" fullword
+    // datadog-agent tracer-fentry-debug.o
+    $ignore_ref = "defer_accept.synflood_warned.you"
   condition:
-    any of them
+    any of ($ref*) and not $ignore_ref
 }

--- a/rules/net/ddos.yara
+++ b/rules/net/ddos.yara
@@ -9,7 +9,7 @@ rule ddos_refs : critical {
     $ref2 = "ackflood" fullword
     $ref3 = "synflood" fullword
     // datadog-agent tracer-fentry-debug.o
-    $ignore_ref = /synflood\_\w+/
+    $ignore_ref = "defer_accept.synflood_warned.you"
   condition:
     any of ($ref*) and not $ignore_ref
 }


### PR DESCRIPTION
Closes: #289 

The original `net/ddos` rule was only matching the `synflood` `fullword` which results in a false positive when scanning the `tracer-fentry-debug.o` file in `datadog-agent` because it's a substring match of `defer_accept.synflood_warned.you`

This PR should resolve the false positive.

How I approached this:
```
$ docker run --rm -it --platform=linux/amd64 --entrypoint sh cgr.dev/chainguard/datadog-agent:latest-dev
...
/ # apk update; apk add vim
/ # xxd -c 32 -g 2 -b /opt/datadog-agent/embedded/share/system-probe/ebpf/co-re/tracer-fentry-debug.o | grep -i synflood
000334a0: 0110010001100101 0110011001100101 0111001001011111 0110000101100011 0110001101100101 0111000001110100 0000000001110011 0111100101101110 0110011001101100 0110111101101111 0110010001011111 0111011101100001 0111001001101110 0110010101100100 0000000001111001 0110111101110101  defer_accept.synflood_warned.you
```