### PR TITLE
Resolve eval false-positive for gawk

### DIFF
--- a/rules/techniques/code_eval.yara
+++ b/rules/techniques/code_eval.yara
@@ -55,7 +55,7 @@ rule php_at_eval : critical {
     hash_2017_tests = "f1a947148c092a58e354e46082b0187bce0eea38fab2a7638eb268da0752657b"
     hash_2017_mybiubiubiu_0_1_1_setup = "afd6712c7c190465c459ab1049cd559e4a2f00a5e1a4e1fe063cfefc19a330ef"
   strings:
-    $at_eval = /@\beval\s*\(\s*(\$\w+|\.\s*"[^"]*"|\.\s*'[^']*'|\w+\(\s*\))/
+    $at_eval = /@\beval\s*\(\s*(\$\w{0,32}|\.\s*"[^"]*"|\.\s*'[^']*'|\w+\(\s*\))/
     $not_empty = "eval()"
   condition:
     $at_eval and none of ($not*)

--- a/rules/techniques/code_eval.yara
+++ b/rules/techniques/code_eval.yara
@@ -55,7 +55,8 @@ rule php_at_eval : critical {
     hash_2017_tests = "f1a947148c092a58e354e46082b0187bce0eea38fab2a7638eb268da0752657b"
     hash_2017_mybiubiubiu_0_1_1_setup = "afd6712c7c190465c459ab1049cd559e4a2f00a5e1a4e1fe063cfefc19a330ef"
   strings:
-    $at_eval = /@eval\s{0,8}\(.{0,32}/
+    $at_eval = /@eval\s{0,8}\([a-z\"\'\(\,\)]{1,32}/
+    $not_empty = "eval()"
   condition:
-    any of them
+    $at_eval and none of ($not*)
 }

--- a/rules/techniques/code_eval.yara
+++ b/rules/techniques/code_eval.yara
@@ -55,7 +55,7 @@ rule php_at_eval : critical {
     hash_2017_tests = "f1a947148c092a58e354e46082b0187bce0eea38fab2a7638eb268da0752657b"
     hash_2017_mybiubiubiu_0_1_1_setup = "afd6712c7c190465c459ab1049cd559e4a2f00a5e1a4e1fe063cfefc19a330ef"
   strings:
-    $at_eval = /@\beval\s*\(\s*(\$\w{0,32}|\.\s*"[^"]*"|\.\s*'[^']*'|\w+\(\s*\))/
+    $at_eval = /@\beval\s{0,32}\(\s{0,32}(\$\w{0,32}|\.\s{0,32}"[^"]{0,32}"|\.\s{0,32}'[^']{0,32}'|\w+\(\s{0,32}\))/
     $not_empty = "eval()"
   condition:
     $at_eval and none of ($not*)

--- a/rules/techniques/code_eval.yara
+++ b/rules/techniques/code_eval.yara
@@ -55,7 +55,7 @@ rule php_at_eval : critical {
     hash_2017_tests = "f1a947148c092a58e354e46082b0187bce0eea38fab2a7638eb268da0752657b"
     hash_2017_mybiubiubiu_0_1_1_setup = "afd6712c7c190465c459ab1049cd559e4a2f00a5e1a4e1fe063cfefc19a330ef"
   strings:
-    $at_eval = /@eval\s{0,8}\([a-z\"\'\(\,\)]{1,32}/
+    $at_eval = /@\beval\s*\(\s*(\$\w+|\.\s*"[^"]*"|\.\s*'[^']*'|\w+\(\s*\))/
     $not_empty = "eval()"
   condition:
     $at_eval and none of ($not*)


### PR DESCRIPTION
Closes: #290 

This PR updates the `php_at_eval` rule to ignore the empty `eval()` string like in the `eval` rule and matches more PHP-specific patterns.

I installed `gawk` and ran the updated rule against the binary and confirmed that there were no matching strings.