### PR TITLE
Tweak password_finder_mimipenguin rule

### DIFF
--- a/rules/combo/stealer/password.yara
+++ b/rules/combo/stealer/password.yara
@@ -6,14 +6,20 @@ rule password_finder_mimipenguin : critical {
     hash_2024_dumpcreds_mimipenguin = "3acfe74cd2567e9cc60cb09bc4d0497b81161075510dd75ef8363f72c49e1789"
     hash_2024_enumeration_linpeas = "210cbe49df69a83462a7451ee46e591c755cfbbef320174dc0ff3f633597b092"
   strings:
-    $lightdm = "lightdm" fullword
-    $apache2 = "apache2.conf" fullword
-    $vsftpd = "vsftpd" fullword
-    $shadow = "/etc/shadow"
-    $gnome = "gnome-keyring-daemon"
-    $password = "password"
-    $finder = "Finder"
-    $sshd_config = "sshd_config" fullword
+    $base_apache_temp = "strings /tmp/apache* | grep -E '^Authorization: Basic.+=$" fullword
+    $base_apache2 = "apache2.conf" fullword
+    $base_finder = /\bFinder\b/
+    $base_gnome_function = "GnomeKeyringPasswordFinder()"
+    $base_gnome_keyring = "gnome-keyring"
+    $base_gnome_keyring_sed = "sed -rn '/gnome\\-keyring\\-daemon/p'"
+    $base_lightdm = "lightdm" fullword
+    $base_mimipenguin = /[Mm]imi[Pp]enguin/
+    $base_pid_dump = "strings \"/tmp/dump.${pid}\" | grep -E -m 1 '^\\$.\\$.+\\$')\"" fullword
+    $base_shadow = "/etc/shadow"
+    $base_sshd_config = "sshd_config" fullword
+    $base_vsftpd = "vsftpd" fullword
+    $extra_password = /\b[Pp]assword\b/
+    $ignore_basic_auth_example = /\w+\:[Pp]assword/
   condition:
-    5 of them
+    5 of ($base_*) and (1 of ($extra_*) and none of ($ignore_*))
 }


### PR DESCRIPTION
Closes: #273

There are a lot of `Finder` and `Password` strings in `/usr/bin/coredns`. 

This PR adds additional strings (sourced from [here](https://github.com/alankrit29/signature-base/blob/master/gen_mimipenguin.yar) and tweaks the conditions to hopefully avoid false positives.

Before:
```
/bincapz # go run . --min-risk 3 /usr/bin/coredns
/usr/bin/coredns [🚨 CRITICAL]
---------------------------------------------------------------------------------------------------
RISK  KEY                          DESCRIPTION                                      EVIDENCE
---------------------------------------------------------------------------------------------------
HIGH  combo/backdoor/payload       load agent with payload                          loadAgent
                                                                                    payload
HIGH  combo/stealer/linux_server   linux server stealer                             .bash_history
                                                                                    .ssh/id_rsa
HIGH  device/hardware/enumeration  linux dmidecode hardware profiler                dmidecode
HIGH  secrets/bash_history         access .bash_history file                        .bash_history
HIGH  shell/bash_dev_tcp           uses /dev/tcp for network access (bash)          /dev/tcp
HIGH  shell/bash_dev_udp           uses /dev/udp for network access (bash)          /dev/udp
HIGH  shell/nohup                  Runs command that is protected from termination  nohup
CRIT  combo/stealer/password       Password finder/dumper, such as MimiPenguin      /etc/shadow
                                                                                    Finder
                                                                                    apache2.conf
                                                                                    password
                                                                                    sshd_config
                                                                                    vsftpd
---------------------------------------------------------------------------------------------------
```

After:
```
/bincapz # go run . --min-risk 3 /usr/bin/coredns
/usr/bin/coredns [🚨 CRITICAL]
---------------------------------------------------------------------------------------------------
RISK  KEY                          DESCRIPTION                                      EVIDENCE
---------------------------------------------------------------------------------------------------
HIGH  combo/backdoor/payload       load agent with payload                          loadAgent
                                                                                    payload
HIGH  combo/stealer/linux_server   linux server stealer                             .bash_history
                                                                                    .ssh/id_rsa
HIGH  device/hardware/enumeration  linux dmidecode hardware profiler                dmidecode
HIGH  secrets/bash_history         access .bash_history file                        .bash_history
HIGH  shell/bash_dev_tcp           uses /dev/tcp for network access (bash)          /dev/tcp
HIGH  shell/bash_dev_udp           uses /dev/udp for network access (bash)          /dev/udp
HIGH  shell/nohup                  Runs command that is protected from termination  nohup
---------------------------------------------------------------------------------------------------
```

@tstromberg  -- do you think the password string(s) still need to be tweaked a bit?