### PR TITLE
Tweak cleanPath function and tests

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -58,6 +58,8 @@ func findFilesRecursively(ctx context.Context, root string, c Config) ([]string,
 
 // cleanPath removes the temporary directory prefix from the path.
 func cleanPath(path string, prefix string) string {
+	// remove any "/private" prefixes from the path
+	path = strings.TrimPrefix(path, "/private")
 	return strings.TrimPrefix(path, prefix)
 }
 

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -57,10 +57,16 @@ func findFilesRecursively(ctx context.Context, root string, c Config) ([]string,
 }
 
 // cleanPath removes the temporary directory prefix from the path.
-func cleanPath(path string, prefix string) string {
-	// remove any "/private" prefixes from the path
-	path = strings.TrimPrefix(path, "/private")
-	return strings.TrimPrefix(path, prefix)
+func cleanPath(path string, prefix string) (string, error) {
+	pathEval, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return "", err
+	}
+	prefixEval, err := filepath.EvalSymlinks(prefix)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimPrefix(pathEval, prefixEval), nil
 }
 
 // formatPath formats the path for display.
@@ -98,7 +104,11 @@ func scanSinglePath(ctx context.Context, c Config, yrs *yara.Rules, path string,
 	// If absPath is provided, use it instead of the path if they are different.
 	// This is useful when scanning images and archives.
 	if absPath != "" && absPath != path && archiveRoot != "" {
-		fr.Path = fmt.Sprintf("%s ∴ %s", absPath, formatPath(cleanPath(path, archiveRoot)))
+		cleanPath, err := cleanPath(path, archiveRoot)
+		if err != nil {
+			return nil, err
+		}
+		fr.Path = fmt.Sprintf("%s ∴ %s", absPath, formatPath(cleanPath))
 	}
 
 	if len(fr.Behaviors) == 0 && c.OmitEmpty {

--- a/pkg/action/scan_test.go
+++ b/pkg/action/scan_test.go
@@ -18,7 +18,7 @@ func TestCleanPath(t *testing.T) {
 	// create and symlink a nested directory
 	// create a file within the nested directory
 	nestedDir := filepath.Join(tempDir, "nested")
-	if err := os.Mkdir(nestedDir, 0755); err != nil {
+	if err := os.Mkdir(nestedDir, 0o755); err != nil {
 		t.Fatalf("failed to create nested directory: %v", err)
 	}
 	symlinkPath := filepath.Join(tempDir, "symlink")
@@ -34,10 +34,10 @@ func TestCleanPath(t *testing.T) {
 	defer file.Close()
 
 	tests := []struct {
-		name      string
-		path      string
-		prefix    string
-		want      string
+		name    string
+		path    string
+		prefix  string
+		want    string
 		wantErr bool
 	}{
 		{


### PR DESCRIPTION
I noticed that tests were failing locally because of this difference (probably macOS-specific?):
```
got "\n# testdata/apko_nested.tar.gz ∴ private/var/folders/2v/jvdj3pbd31g8q_m_70d094zr0000gn/T/apko_nested.tar.gz424237489/apko_0.13.2_linux_arm64/apko
...
want "\n# testdata/apko_nested.tar.gz ∴ apko_0.13.2_linux_arm64/apko
```

The path looks like this:
```
msg=scanning path=/private/var/folders/2v/jvdj3pbd31g8q_m_70d094zr0000gn/T/apko_nested.tar.gz424237489/apko_0.13.2_linux_arm64/apko
```

and we're expecting the path to be `/var/folders/2v/jvdj3pbd31g8q_m_70d094zr0000gn/T/apko_nested.tar.gz424237489/apko_0.13.2_linux_arm64/apko` so that we can remove the `archiveRoot` from the path. This mismatch was returning the path unchanged.

On `main`:
```
archive_test.go:262: got "\n# testdata/apko_nested.tar.gz ∴ private/var/folders/2v/jvdj3pbd31g8q_m_70d094zr0000gn/T/apko_nested.tar.gz424237489/apko_0.13.2_linux_arm64/apko\narchives/zip\ncombo/dropper/shell\ncombo/stealer/ssh\ncompression/bzip2\ncompression/gzip\ncompression/zstd\ncrypto/aes\ncrypto/ecdsa\ncrypto/ed25519\ncrypto/tls\ndata/embedded/pem/certificate\ndata/embedded/pem/test_key\ndata/embedded/ssh/signature\ndata/embedded/zstd\nencoding/base64\nencoding/json\nencoding/json/decode\nencoding/json/encode\nenv/HOME\nenv/USER\nevasion/content/length/0\nexec/program\nfs/blkid\nfs/directory/create\nfs/directory/list\nfs/directory/remove\nfs/fifo/create\nfs/file/delete\nfs/file/read\nfs/file/stat\nfs/file/write\nfs/link/create\nfs/link/read\nfs/lock/update\nfs/mount\nfs/node/create\nfs/permission/chown\nfs/permission/modify\nfs/swap/off\nfs/swap/on\nfs/symlink/resolve\nfs/tempfile/create\nfs/unmount\nhash/blake2b\nhash/md5\nkernel/cpu/info\nkernel/hostname/get\nkernel/netlink\nkernel/pivot_root\nkernel/platform\nnet/dns\nnet/dns/reverse\nnet/dns/txt\nnet/download\nnet/fetch\nnet/hostname/resolve\nnet/http/accept/encoding\nnet/http/auth\nnet/http/cookies\nnet/http/form/upload\nnet/http/post\nnet/http/request\nnet/http2\nnet/http_proxy\nnet/interface/list\nnet/ip\nnet/ip/parse\nnet/mac/address\nnet/sendfile\nnet/socket/listen\nnet/socket/local/address\nnet/socket/peer/address\nnet/socket/receive\nnet/socket/send\nnet/socks5\nnet/ssh\nnet/stat\nnet/udp/receive\nnet/udp/send\nnet/upload\nnet/url\nnet/url/encode\nnet/url/request\nprocess/chdir\nprocess/chroot\nprocess/find\nprocess/groups/set\nprocess/unshare\nprocess/username/get\nref/daemon\nref/ip_port\nref/path/bin/su\nref/path/etc\nref/path/etc/hosts\nref/path/etc/resolv.conf\nref/path/hidden\nref/path/home\nref/path/home/config\nref/path/relative\nref/path/root\nref/path/usr/bin\nref/path/usr/local\nref/path/usr/sbin\nref/path/var\nref/site/url\nref/words/exclamation\nref/words/heartbeat\nref/words/password\nref/words/plugin\nref/words/server_address\nsecrets/keychain\nsecrets/private_key\nsecrets/ssh\nsecurity_controls/linux/selinux\nshell/background/sleep\nshell/exec\ntime/clock/set", want "\n# testdata/apko_nested.tar.gz ∴ apko_0.13.2_linux_arm64/apko\narchives/zip\ncombo/dropper/shell\ncombo/stealer/ssh\ncompression/bzip2\ncompression/gzip\ncompression/zstd\ncrypto/aes\ncrypto/ecdsa\ncrypto/ed25519\ncrypto/tls\ndata/embedded/pem/certificate\ndata/embedded/pem/test_key\ndata/embedded/ssh/signature\ndata/embedded/zstd\nencoding/base64\nencoding/json\nencoding/json/decode\nencoding/json/encode\nenv/HOME\nenv/USER\nevasion/content/length/0\nexec/program\nfs/blkid\nfs/directory/create\nfs/directory/list\nfs/directory/remove\nfs/fifo/create\nfs/file/delete\nfs/file/read\nfs/file/stat\nfs/file/write\nfs/link/create\nfs/link/read\nfs/lock/update\nfs/mount\nfs/node/create\nfs/permission/chown\nfs/permission/modify\nfs/swap/off\nfs/swap/on\nfs/symlink/resolve\nfs/tempfile/create\nfs/unmount\nhash/blake2b\nhash/md5\nkernel/cpu/info\nkernel/hostname/get\nkernel/netlink\nkernel/pivot_root\nkernel/platform\nnet/dns\nnet/dns/reverse\nnet/dns/txt\nnet/download\nnet/fetch\nnet/hostname/resolve\nnet/http/accept/encoding\nnet/http/auth\nnet/http/cookies\nnet/http/form/upload\nnet/http/post\nnet/http/request\nnet/http2\nnet/http_proxy\nnet/interface/list\nnet/ip\nnet/ip/parse\nnet/mac/address\nnet/sendfile\nnet/socket/listen\nnet/socket/local/address\nnet/socket/peer/address\nnet/socket/receive\nnet/socket/send\nnet/socks5\nnet/ssh\nnet/stat\nnet/udp/receive\nnet/udp/send\nnet/upload\nnet/url\nnet/url/encode\nnet/url/request\nprocess/chdir\nprocess/chroot\nprocess/find\nprocess/groups/set\nprocess/unshare\nprocess/username/get\nref/daemon\nref/ip_port\nref/path/bin/su\nref/path/etc\nref/path/etc/hosts\nref/path/etc/resolv.conf\nref/path/hidden\nref/path/home\nref/path/home/config\nref/path/relative\nref/path/root\nref/path/usr/bin\nref/path/usr/local\nref/path/usr/sbin\nref/path/var\nref/site/url\nref/words/exclamation\nref/words/heartbeat\nref/words/password\nref/words/plugin\nref/words/server_address\nsecrets/keychain\nsecrets/private_key\nsecrets/ssh\nsecurity_controls/linux/selinux\nshell/background/sleep\nshell/exec\ntime/clock/set"
```

With this fix:
```
$ make test
go test ./...
?   	github.com/chainguard-dev/bincapz	[no test files]
?   	github.com/chainguard-dev/bincapz/pkg/bincapz	[no test files]
?   	github.com/chainguard-dev/bincapz/pkg/compile	[no test files]
?   	github.com/chainguard-dev/bincapz/pkg/render	[no test files]
?   	github.com/chainguard-dev/bincapz/pkg/version	[no test files]
?   	github.com/chainguard-dev/bincapz/rules	[no test files]
?   	github.com/chainguard-dev/bincapz/samples/does-nothing	[no test files]
?   	github.com/chainguard-dev/bincapz/third_party	[no test files]
ok  	github.com/chainguard-dev/bincapz/pkg/action	6.438s
ok  	github.com/chainguard-dev/bincapz/pkg/profile	0.513s
ok  	github.com/chainguard-dev/bincapz/pkg/report	0.233s
ok  	github.com/chainguard-dev/bincapz/samples	13.609s
```