### PR TITLE
Bump bincapz version to 0.14.0 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.13.2"
+	ID string = "v0.14.0"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
Before cutting the new release, `version.go` should match.