### PR TITLE
Remove OmitEmpty; fix nil pointer dereference

### DIFF
--- a/bincapz.go
+++ b/bincapz.go
@@ -69,7 +69,6 @@ func main() {
 	errFirstMissFlag := flag.Bool("err-first-miss", false, "exit with error if scan source has no matching capabilities")
 	errFirstHitFlag := flag.Bool("err-first-hit", false, "exit with error if scan source has matching capabilities")
 	ociFlag := flag.Bool("oci", false, "Scan an OCI image")
-	omitEmptyFlag := flag.Bool("omit-empty", false, "Omit files that contain no matches")
 	quantityIncreasesRiskFlag := flag.Bool("quantity-increases-risk", true, "increase file risk score based on behavior quantity")
 	profileFlag := flag.Bool("profile", false, "Generate profile and trace files")
 	statsFlag := flag.Bool("stats", false, "Show statistics about the scan")
@@ -187,7 +186,6 @@ func main() {
 		MinRisk:               minRisk,
 		QuantityIncreasesFisk: *quantityIncreasesRiskFlag,
 		OCI:                   *ociFlag,
-		OmitEmpty:             *omitEmptyFlag,
 		Renderer:              renderer,
 		Rules:                 yrs,
 		ScanPaths:             args,

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -102,7 +102,7 @@ func scanSinglePath(ctx context.Context, c bincapz.Config, yrs *yara.Rules, path
 		fr.Path = fmt.Sprintf("%s ∴ %s", absPath, formatPath(cleanPath))
 	}
 
-	if len(fr.Behaviors) == 0 && c.OmitEmpty {
+	if len(fr.Behaviors) == 0 {
 		return nil, nil
 	}
 
@@ -296,13 +296,14 @@ func processFile(ctx context.Context, c bincapz.Config, yrs *yara.Rules, path st
 		logger.Errorf("scan path: %v", err)
 		return nil, nil
 	}
-	if fr.Error != "" {
-		logger.Debugf("scan error: %s", fr.Error)
-		return nil, nil
-	}
 
 	if fr == nil {
 		logger.Infof("%s returned nil result", path)
+		return nil, nil
+	}
+
+	if fr.Error != "" {
+		logger.Errorf("scan error: %s", fr.Error)
 		return nil, nil
 	}
 

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -103,7 +103,7 @@ func scanSinglePath(ctx context.Context, c bincapz.Config, yrs *yara.Rules, path
 	}
 
 	if len(fr.Behaviors) == 0 {
-		return nil, nil
+		return &bincapz.FileReport{Path: path}, nil
 	}
 
 	return &fr, nil

--- a/pkg/bincapz/bincapz.go
+++ b/pkg/bincapz/bincapz.go
@@ -24,7 +24,6 @@ type Config struct {
 	MinFileRisk           int
 	MinRisk               int
 	OCI                   bool
-	OmitEmpty             bool
 	Output                io.Writer
 	Renderer              Renderer
 	Rules                 *yara.Rules


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/348

This PR removes the [unused] `--omit-empty` flag. 

Additionally, since we're now returning `nil` when only `len(fr.Behaviors)` is `0`, the ordering of `if fr.Error != "" { ... }` before `if fr == nil { ... }` was causing a nil pointer dereference so I fixed that as well.