### PR TITLE
Consolidate reverse_shell rules

### DIFF
--- a/rules/shell/reverse.yara
+++ b/rules/shell/reverse.yara
@@ -1,17 +1,24 @@
 
 rule reverse_shell : high {
   meta:
-    hash_2023_UPX_0c25a05bdddc144fbf1ffa29372481b50ec6464592fdfb7dec95d9e1c6101d0d_elf_x86_64 = "818b80a08418f3bb4628edd4d766e4de138a58f409a89a5fdba527bab8808dd2"
-    hash_2023_OK_ad69 = "ad69e198905a8d4a4e5c31ca8a3298a0a5d761740a5392d2abb5d6d2e966822f"
+    description = "references a reverse shell"
+    hash_2023_0xShell_wesoori = "bab1040a9e569d7bf693ac907948a09323c5f7e7005012f7b75b5c1b2ced10ad"
     hash_2023_ciscotools_4247 = "42473f2ab26a5a118bd99885b5de331a60a14297219bf1dc1408d1ede7d9a7a6"
+    hash_2023_OK_ad69 = "ad69e198905a8d4a4e5c31ca8a3298a0a5d761740a5392d2abb5d6d2e966822f"
+    hash_2023_UPX_0c25a05bdddc144fbf1ffa29372481b50ec6464592fdfb7dec95d9e1c6101d0d_elf_x86_64 = "818b80a08418f3bb4628edd4d766e4de138a58f409a89a5fdba527bab8808dd2"
+    hash_2024_D3m0n1z3dShell_demonizedshell = "d7c34b9d711260c1cd001ca761f5df37cbe40b492f198b228916b6647b660119"
+    hash_2024_locutus_borg_transwarp = "4573af129e3e1a197050e2fd066f846c92de64d8d14a81a13d975a2cbc6d391e"
   strings:
-    $bash_dev_tcp = "bash -i >& /dev/tcp/"
-    $stdin_redir = "0>&1" fullword
-    $reverse_shell = "reverse_shell"
-    $reverse_space_shell = "reverse shell" nocase fullword
-    $revshell = "revshell"
+    $r_bash_dev_tcp = "bash -i >& /dev/tcp/"
+    $r_reverse_or_web_shell = /(r[e3]v[e3]rs[e3]|w[3e]b)\s*sh[e3]ll/ nocase
+    $r_reverse_shell = "reverse_shell"
+    $r_reverse_space_shell = "reverse shell" nocase fullword
+    $r_revshell = "revshell"
+    $r_stdin_redir = "0>&1" fullword
+    $not_ref_1 = "reverse shellConf"
+    $not_ref_2 = "reverse shellshare"
   condition:
-    any of them
+    any of ($r_*) and none of ($not_*)
 }
 
 rule mkfifo_netcat : critical {
@@ -38,18 +45,4 @@ rule perl_reverse_shell : critical {
     $sh_i = "sh -i"
   condition:
     $socket and $open and any of ($redir*) and $sh_i
-}
-
-rule reverse_shell_ref : high {
-  meta:
-    description = "references a reverse shell"
-    hash_2023_0xShell_wesoori = "bab1040a9e569d7bf693ac907948a09323c5f7e7005012f7b75b5c1b2ced10ad"
-    hash_2024_D3m0n1z3dShell_demonizedshell = "d7c34b9d711260c1cd001ca761f5df37cbe40b492f198b228916b6647b660119"
-    hash_2024_locutus_borg_transwarp = "4573af129e3e1a197050e2fd066f846c92de64d8d14a81a13d975a2cbc6d391e"
-  strings:
-    $ref = /(r[e3]v[e3]rs[e3]|w[3e]b)\s*sh[e3]ll/ nocase
-    $not_ref_1 = "reverse shellConf"
-    $not_ref_2 = "reverse shellshare"
-  condition:
-    $ref and none of ($not_*)
 }


### PR DESCRIPTION
Since the `reverse_shell` rule is now `high`, it makes sense to add the ref from `reverse_shell_ref` to that rule so that we only need to maintain a single rule.

I ran `make refresh-sample-testdata` and none of the simple reports changed so this rule is working exactly the same as the two separate rules were.