### PR TITLE
Calculate scores and moves for JSON files and numbered file names

### DIFF
--- a/samples/Linux/clean/aws-c-io/aws-c-io-0.14.10-r0.spdx.json
+++ b/samples/Linux/clean/aws-c-io/aws-c-io-0.14.10-r0.spdx.json
@@ -1,0 +1,55 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "apk-aws-c-io-0.14.10-r0",
+    "spdxVersion": "SPDX-2.3",
+    "creationInfo": {
+      "created": "1970-01-01T00:00:00Z",
+      "creators": [
+        "Tool: melange (v0.10.4-8-gad395d6)",
+        "Organization: Chainguard, Inc"
+      ],
+      "licenseListVersion": "3.22"
+    },
+    "dataLicense": "CC0-1.0",
+    "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/d78f12f61987666c28b8b492d748",
+    "documentDescribes": [
+      "SPDXRef-Package-aws-c-io-0.14.10-r0"
+    ],
+    "packages": [
+      {
+        "SPDXID": "SPDXRef-Package-aws-c-io-0.14.10-r0",
+        "name": "aws-c-io",
+        "versionInfo": "0.14.10-r0",
+        "filesAnalyzed": false,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "Apache-2.0",
+        "downloadLocation": "NOASSERTION",
+        "originator": "Organization: Wolfi",
+        "supplier": "Organization: Wolfi",
+        "copyrightText": "\n",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:apk/wolfi/aws-c-io@0.14.10-r0?arch=x86_64",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/awslabs/aws-c-io@v0.14.10",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/awslabs/aws-c-io@d04508d113851f1bc15630d93490b2aa09676137",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/wolfi-dev/os@d5a1590aa230376450bcee3bd73692af6382ddb1#aws-c-io.yaml",
+            "referenceType": "purl"
+          }
+        ]
+      }
+    ],
+    "relationships": []
+  }

--- a/samples/Linux/clean/aws-c-io/aws-c-io-0.14.11-r0.spdx.json
+++ b/samples/Linux/clean/aws-c-io/aws-c-io-0.14.11-r0.spdx.json
@@ -1,0 +1,56 @@
+{
+    "SPDXID": "SPDXRef-DOCUMENT",
+    "name": "apk-aws-c-io-0.14.11-r0",
+    "spdxVersion": "SPDX-2.3",
+    "creationInfo": {
+      "created": "1970-01-01T00:00:00Z",
+      "creators": [
+        "Tool: melange (v0.10.4-8-gad395d6)",
+        "Organization: Chainguard, Inc"
+      ],
+      "licenseListVersion": "3.22"
+    },
+    "dataLicense": "CC0-1.0",
+    "documentNamespace": "https://spdx.org/spdxdocs/chainguard/melange/07691057f87b3b0e303145c07af4281103d5b91e",
+    "documentDescribes": [
+      "SPDXRef-Package-aws-c-io-0.14.11-r0"
+    ],
+    "packages": [
+      {
+        "SPDXID": "SPDXRef-Package-aws-c-io-0.14.11-r0",
+        "name": "aws-c-io",
+        "versionInfo": "0.14.11-r0",
+        "filesAnalyzed": false,
+        "licenseConcluded": "NOASSERTION",
+        "licenseDeclared": "Apache-2.0",
+        "downloadLocation": "NOASSERTION",
+        "originator": "Organization: Wolfi",
+        "supplier": "Organization: Wolfi",
+        "copyrightText": "\n",
+        "externalRefs": [
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:apk/wolfi/aws-c-io@0.14.11-r0?arch=x86_64",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/awslabs/aws-c-io@v0.14.11",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/awslabs/aws-c-io@d04508d113851f1bc15630d93490b2aa09676137",
+            "referenceType": "purl"
+          },
+          {
+            "referenceCategory": "PACKAGE_MANAGER",
+            "referenceLocator": "pkg:github/wolfi-dev/os@d5a1590aa230376450bcee3bd73692af6382ddb1#aws-c-io.yaml",
+            "referenceType": "purl"
+          }
+        ]
+      }
+    ],
+    "relationships": []
+  }
+  

--- a/samples/Linux/clean/aws-c-io/aws-c-io.sdiff
+++ b/samples/Linux/clean/aws-c-io/aws-c-io.sdiff
@@ -1,0 +1,1 @@
+*** changed: Linux/clean/aws-c-io/aws-c-io-0.14.11-r0.spdx.json

--- a/samples/refresh-testdata.sh
+++ b/samples/refresh-testdata.sh
@@ -72,6 +72,12 @@ ${bincapz} --format=simple \
     Linux/2023.FreeDownloadManager/freedownloadmanager_clear_postinst \
     Linux/2023.FreeDownloadManager/freedownloadmanager_infected_postinst &
 
+${bincapz} --format=simple \
+    --diff \
+    -o Linux/clean/aws-c-io/aws-c-io.sdiff \
+    Linux/clean/aws-c-io/aws-c-io-0.14.10-r0.spdx.json \
+    Linux/clean/aws-c-io/aws-c-io-0.14.11-r0.spdx.json &
+
 wait
 
 for f in $(find * -name "*.simple"); do

--- a/samples/samples_test.go
+++ b/samples/samples_test.go
@@ -190,6 +190,7 @@ func TestDiff(t *testing.T) {
 		// Important: minFileScore should apply to source or destination
 		{diff: "macOS/clean/ls.sdiff.trigger_3", format: "simple", src: "Linux/clean/ls.x86_64", dest: "macOS/clean/ls", minResultScore: 1, minFileScore: 3},
 		{diff: "Linux/2024.sbcl.market/sbcl.sdiff", format: "simple", src: "Linux/2024.sbcl.market/sbcl.clean", dest: "Linux/2024.sbcl.market/sbcl.dirty"},
+		{diff: "Linux/clean/aws-c-io/aws-c-io.sdiff", format: "simple", src: "Linux/clean/aws-c-io/aws-c-io-0.14.10-r0.spdx.json", dest: "Linux/clean/aws-c-io/aws-c-io-0.14.11-r0.spdx.json"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
This is a stop-gap PR while #356 is being worked on. 

For now, we'll allow JSON files, `.so` library files, and files with numbered file names to have their scores and moves calculated.