### PR TITLE
Bump bincapz version to 0.15.0 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.14.0"
+	ID string = "v0.15.0"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
This PR bumps the semver to `0.15.0` before we cut the release.

TODO: finish up the automation for this (i.e., creating the PR).