### PR TITLE
Fix broken, nested extractions

### DIFF
--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -250,13 +250,13 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 	}
 	err = extract(ctx, tmpDir, path)
 	if err != nil {
-		return "", fmt.Errorf("extract: %w", err)
+		return "", fmt.Errorf("failed to extract %s: %w", path, err)
 	}
 
 	extractedFiles := make(map[string]bool)
 	files, err := os.ReadDir(tmpDir)
 	if err != nil {
-		return "", fmt.Errorf("failed to read directory: %w", err)
+		return "", fmt.Errorf("failed to read files in directory %s: %w", tmpDir, err)
 	}
 	for _, file := range files {
 		extractedFiles[filepath.Join(tmpDir, file.Name())] = false
@@ -266,7 +266,7 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 		ext := getExt(file)
 		info, err := os.Stat(file)
 		if err != nil {
-			return "", fmt.Errorf("failed to stat file: %w", err)
+			return "", fmt.Errorf("failed to stat file %s: %w", file, err)
 		}
 		switch mode := info.Mode(); {
 		case mode.IsDir():
@@ -280,7 +280,7 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 				}
 				if !d.IsDir() {
 					if err := extractNestedArchive(ctx, tmpDir, rel, extractedFiles); err != nil {
-						return fmt.Errorf("extract nested archive: %w", err)
+						return fmt.Errorf("failed to extract nested archive %s: %w", rel, err)
 					}
 				}
 
@@ -294,7 +294,7 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 					return "", fmt.Errorf("filepath.Rel: %w", err)
 				}
 				if err := extractNestedArchive(ctx, tmpDir, rel, extractedFiles); err != nil {
-					return "", fmt.Errorf("extract nested archive: %w", err)
+					return "", fmt.Errorf("extract nested archive %s: %w", rel, err)
 				}
 			}
 			return tmpDir, nil


### PR DESCRIPTION
I noticed this when attempting to scan a Wolfi package artifact, in this case the `aws-c-io` `packages-x86_64.zip` artifact. The existing nested archive extraction was essentially non-functional so I spent some time fixing this up (this should make scanning more seamless for various combinations of nested archive types).

Before (verbose logging to capture the EOF error):
```
time=2024-07-12T17:37:05.185-05:00 level=INFO source=/.../.../repos/bincapz/pkg/action/scan.go:78 msg=scanning path=/private/var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/packages-x86_64.zip2229945561/packages/x86_64/aws-c-io-dev-0.14.11-r0.apk kind=""
time=2024-07-12T17:37:05.185-05:00 level=DEBUG source=/.../.../repos/bincapz/pkg/action/programkind.go:91 msg=magic path=/private/var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/packages-x86_64.zip2229945561/packages.log desc="" header="x86_64|aws-c-io|aws-c-io|0.14.11-r0\nx86_64|aws-c-io|aws-c-io-dev|0.14.11-r0\n" err="unexpected EOF"
time=2024-07-12T17:37:05.185-05:00 level=INFO source=/.../.../repos/bincapz/pkg/action/scan.go:78 msg=scanning path=/private/var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/packages-x86_64.zip2229945561/packages.log kind=""
time=2024-07-12T17:37:05.186-05:00 level=DEBUG source=/.../.../repos/bincapz/pkg/action/scan.go:253 msg="recursive scan complete: 0 files"
```

> `time=2024-07-12T17:37:05.185-05:00 level=DEBUG source=/.../.../repos/bincapz/pkg/action/programkind.go:91 msg=magic path=/private/var/folders/n6/xxn5d2zd3l1gghpx_7qppzs00000gn/T/packages-x86_64.zip2229945561/packages.log desc="" header="x86_64|aws-c-io|aws-c-io|0.14.11-r0\nx86_64|aws-c-io|aws-c-io-dev|0.14.11-r0\n" err="unexpected EOF"
`

After:
```
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/channel.h
net/socket/send
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/channel_bootstrap.h
net/socket/listen
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/host_resolver.h
net/hostport/parse
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/retry_strategy.h
net/socket/connect
ref/site/url
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/socket.h
net/socket/connect
net/socket/listen
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/io/tls_channel_handler.h
ref/path/etc
ref/words/password
secrets/keychain
secrets/private_key
# /.../.../Downloads/packages-x86_64.zip ∴ usr/include/aws/testing/io_testing_channel.h
net/socket/send
# /.../.../Downloads/packages-x86_64.zip ∴ usr/lib/libaws-c-io.so.1.0.0
crypto/aes
dylib/symbol/address
encoding/base64
evasion/base64/decode
fd/epoll
hash/md5
hash/sha1
hash/sha256
net/hostport/parse
net/ip/parse
net/ip/string
net/reuseport
net/socket/listen
net/socket/local/address
net/socket/receive
net/socket/send
process/thread_local_storage
ref/path/etc
secrets/keychain
secrets/private_key
# /.../.../Downloads/packages-x86_64.zip ∴ var/lib/db/sbom/aws-c-io-0.14.11-r0.spdx.json
net/download
ref/site/url
# /.../.../Downloads/packages-x86_64.zip ∴ var/lib/db/sbom/aws-c-io-dev-0.14.11-r0.spdx.json
net/download
ref/site/url
```

This has likely been broken since I originally added support for nested extractions. We still can't extract arbitrarily-nested archives (which is probably a good thing) but this PR will at least solve for this edge case.