### PR TITLE
Bump bincapz version to 0.15.1 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.15.0"
+	ID string = "v0.15.1"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
Bump the bincapz version string to `0.15.1` before we cut the new release for #360.