### PR TITLE
Turn off ELCEEF_HTML_Smuggling_A rule; fix OCI scanning and path displays

### DIFF
--- a/pkg/action/oci_test.go
+++ b/pkg/action/oci_test.go
@@ -41,17 +41,13 @@ func TestOCI(t *testing.T) {
 		t.Fatalf("render: %v", err)
 	}
 
-	sp, err := oci(ctx, "cgr.dev/chainguard/static")
-	if err != nil {
-		t.Fatalf("oci: %v", err)
-	}
-
 	bc := bincapz.Config{
 		IgnoreSelf: false,
 		IgnoreTags: []string{"harmless"},
 		Renderer:   simple,
 		Rules:      yrs,
-		ScanPaths:  []string{sp},
+		ScanPaths:  []string{"cgr.dev/chainguard/static"},
+		OCI:        true,
 	}
 	res, err := Scan(ctx, bc)
 	if err != nil {
@@ -60,11 +56,6 @@ func TestOCI(t *testing.T) {
 	if err := simple.Full(ctx, res); err != nil {
 		t.Fatalf("full: %v", err)
 	}
-
-	// Remove the header since it is not deterministic
-	// due to the usage of temporary directories
-	idx := bytes.IndexByte(out.Bytes(), '\n')
-	out.Next(idx + 1)
 
 	got := reduceMarkdown(out.String())
 

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -65,7 +65,7 @@ func formatPath(path string) string {
 	if strings.Contains(path, "\\") {
 		path = strings.ReplaceAll(path, "\\", "/")
 	}
-	return strings.TrimPrefix(path, "/")
+	return path
 }
 
 // scanSinglePath YARA scans a single path and converts it to a fileReport.

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -87,7 +87,7 @@ func scanSinglePath(ctx context.Context, c bincapz.Config, yrs *yara.Rules, path
 		return &bincapz.FileReport{Path: path, Error: fmt.Sprintf("scanfile: %v", err)}, nil
 	}
 
-	fr, err := report.Generate(ctx, path, mrs, c)
+	fr, err := report.Generate(ctx, path, mrs, c, archiveRoot)
 	if err != nil {
 		return nil, err
 	}
@@ -213,12 +213,14 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 				continue
 			}
 
+			trimPath := ""
 			if c.OCI {
 				scanPath = imageURI
+				trimPath = ociExtractPath
 			}
 
-			logger.Debug("processing path path", slog.Any("path", path))
-			fr, err := processFile(ctx, c, yrs, path, scanPath, "", logger)
+			logger.Debug("processing path", slog.Any("path", path))
+			fr, err := processFile(ctx, c, yrs, path, scanPath, trimPath, logger)
 			if err != nil {
 				return r, err
 			}

--- a/pkg/action/scan_test.go
+++ b/pkg/action/scan_test.go
@@ -107,17 +107,17 @@ func TestFormatPath(t *testing.T) {
 		{
 			name: "single separator",
 			path: "/apko_0.13.2_linux_arm64/apko",
-			want: "apko_0.13.2_linux_arm64/apko",
+			want: "/apko_0.13.2_linux_arm64/apko",
 		},
 		{
 			name: "multiple separators",
 			path: "/usr/share/zoneinfo/zone1970",
-			want: "usr/share/zoneinfo/zone1970",
+			want: "/usr/share/zoneinfo/zone1970",
 		},
 		{
 			name: "multiple windows separators",
 			path: "\\usr\\share\\zoneinfo\\zone1970",
-			want: "usr/share/zoneinfo/zone1970",
+			want: "/usr/share/zoneinfo/zone1970",
 		},
 	}
 	for _, tt := range tests {

--- a/pkg/action/testdata/scan_archive
+++ b/pkg/action/testdata/scan_archive
@@ -1,5 +1,5 @@
 
-# testdata/apko_nested.tar.gz ∴ apko_0.13.2_linux_arm64/apko
+# testdata/apko_nested.tar.gz ∴ /apko_0.13.2_linux_arm64/apko
 archives/zip
 combo/dropper/shell
 compression/bzip2

--- a/pkg/action/testdata/scan_oci
+++ b/pkg/action/testdata/scan_oci
@@ -1,15 +1,15 @@
-# cgr.dev/chainguard/static ∴ etc/profile
+# cgr.dev/chainguard/static ∴ /etc/profile
 persist/bash
 persist/shell/init_files
 ref/path/etc
 ref/path/usr/local
-# cgr.dev/chainguard/static ∴ var/lib/db/sbom/ca-certificates-bundle-20240705-r0.spdx.json
+# cgr.dev/chainguard/static ∴ /var/lib/db/sbom/ca-certificates-bundle-20240705-r0.spdx.json
 net/download
 ref/site/url
-# cgr.dev/chainguard/static ∴ var/lib/db/sbom/tzdata-2024a-r3.spdx.json
+# cgr.dev/chainguard/static ∴ /var/lib/db/sbom/tzdata-2024a-r3.spdx.json
 net/download
 ref/site/url
 time/tzinfo
-# cgr.dev/chainguard/static ∴ var/lib/db/sbom/wolfi-baselayout-20230201-r13.spdx.json
+# cgr.dev/chainguard/static ∴ /var/lib/db/sbom/wolfi-baselayout-20230201-r13.spdx.json
 net/download
 ref/site/url

--- a/pkg/action/testdata/scan_oci
+++ b/pkg/action/testdata/scan_oci
@@ -1,4 +1,15 @@
+# cgr.dev/chainguard/static ∴ etc/profile
 persist/bash
 persist/shell/init_files
 ref/path/etc
 ref/path/usr/local
+# cgr.dev/chainguard/static ∴ var/lib/db/sbom/ca-certificates-bundle-20240705-r0.spdx.json
+net/download
+ref/site/url
+# cgr.dev/chainguard/static ∴ var/lib/db/sbom/tzdata-2024a-r3.spdx.json
+net/download
+ref/site/url
+time/tzinfo
+# cgr.dev/chainguard/static ∴ var/lib/db/sbom/wolfi-baselayout-20230201-r13.spdx.json
+net/download
+ref/site/url

--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -24,6 +24,7 @@ var badRules = map[string]bool{
 	"GODMODERULES_IDDQD_God_Mode_Rule":            true,
 	"MALPEDIA_Win_Unidentified_107_Auto":          true,
 	"SIGNATURE_BASE_SUSP_PS1_JAB_Pattern_Jun22_1": true,
+	"ELCEEF_HTML_Smuggling_A":                     true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,

--- a/pkg/report/report.go
+++ b/pkg/report/report.go
@@ -294,7 +294,7 @@ func mungeDescription(s string) string {
 }
 
 //nolint:cyclop // ignore complexity of 44
-func Generate(ctx context.Context, path string, mrs yara.MatchRules, c bincapz.Config) (bincapz.FileReport, error) {
+func Generate(ctx context.Context, path string, mrs yara.MatchRules, c bincapz.Config, expath string) (bincapz.FileReport, error) {
 	ignoreTags := c.IgnoreTags
 	minScore := c.MinRisk
 	ignoreSelf := c.IgnoreSelf
@@ -307,6 +307,10 @@ func Generate(ctx context.Context, path string, mrs yara.MatchRules, c bincapz.C
 	size, checksum, err := sizeAndChecksum(path)
 	if err != nil {
 		return bincapz.FileReport{}, err
+	}
+
+	if c.OCI {
+		path = strings.TrimPrefix(path, expath)
 	}
 
 	fr := bincapz.FileReport{


### PR DESCRIPTION
This PR turns off a third-party rule causing false positives as seen here: https://github.com/wolfi-dev/os/pull/23972 (WebPack chunks -- SuperSet is written in TypeScript and definitely uses WebPack as seen [here](https://github.com/apache/superset/blob/master/superset-frontend/webpack.config.js))

Rule match:
```sh
$ yara -r third_party/yara/YARAForge/yara-rules-full.yar /tmp/bincapz/superset/packages/x86_64/app/superset/static/assets/382fcea1a788951d14e0.chunk.js -s
ELCEEF_HTML_Smuggling_A /tmp/bincapz/superset/packages/x86_64/app/superset/static/assets/382fcea1a788951d14e0.chunk.js
0x5878:$mssave: 22 6D 73 53 61 76 65
0x5955:$mssave: 2E 6D 73 53 61 76 65
0x42b:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x45f:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x1c14:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x20e4:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x246a:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x2773:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x2848:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x303d:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x574e:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x58f9:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x2b515:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x2cb23:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x3082e:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x4c1cf:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x595e0:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x596e6:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x5bef9:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x5bf89:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x5cfd9:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x5d005:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x89e8e:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x8a85d:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0xa0406:$element: 2E 63 72 65 61 74 65 45 6C 65 6D 65 6E 74 28
0x5809:$objecturl: 2E 63 72 65 61 74 65 4F 62 6A 65 63 74 55 52 4C 28
0x5ce0:$objecturl: 2E 63 72 65 61 74 65 4F 62 6A 65 63 74 55 52 4C 28
0xf228:$objecturl: 2E 63 72 65 61 74 65 4F 62 6A 65 63 74 55 52 4C 28
0x56f2:$download: 22 64 6F 77 6E 6C 6F 61 64 22
0x576f:$download: 22 64 6F 77 6E 6C 6F 61 64 22
0x577b:$download: 2E 64 6F 77 6E 6C 6F 61 64 3D
0x58b7:$download: 22 64 6F 77 6E 6C 6F 61 64 22
0x55c2:$click: 22 63 6C 69 63 6B 22
0x5610:$click: 22 63 6C 69 63 6B 22
0x7014c:$click: 22 63 6C 69 63 6B 22
0x75bdf:$click: 22 63 6C 69 63 6B 22
0x7e52d:$click: 22 63 6C 69 63 6B 22
0x7eddc:$click: 22 63 6C 69 63 6B 22
0x7ee89:$click: 22 63 6C 69 63 6B 22
0x7ef2c:$click: 22 63 6C 69 63 6B 22
0x7f06e:$click: 22 63 6C 69 63 6B 22
0x7f109:$click: 22 63 6C 69 63 6B 22
0x8b9fe:$click: 22 63 6C 69 63 6B 22
0x991b4:$click: 22 63 6C 69 63 6B 22
0x34e:$atob: 61 74 6F 62 28
0x3b2:$blob: new Blob(
0x5a60:$blob: new Blob(
0xf08b:$blob: new Blob(
0x37d:$array: new Uint8Array(
0x9c8d:$array: new Uint8Array(
0x1d142:$array: new Uint8Array(
0x1e212:$array: new Uint8Array(
0x1e29c:$array: new Uint8Array(
0x2ac22:$array: new Uint8Array(
0x2f1d5:$array: new Uint8Array(
0x2fd8f:$array: new Uint8Array(
0x2ffba:$array: new Uint8Array(
0x3001f:$array: new Uint8Array(
0x300d4:$array: new Uint8Array(
0x304f3:$array: new Uint8Array(
0x3077b:$array: new Uint8Array(
0x30a43:$array: new Uint8Array(
0x3162e:$array: new Uint8Array(
0x31831:$array: new Uint8Array(
0x331e8:$array: new Uint8Array(
0x3a8ac:$array: new Uint8Array(
0x43dca:$array: new Uint8Array(
0x44290:$array: new Uint8Array(
0x443ba:$array: new Uint8Array(
0x443ec:$array: new Uint8Array(
0x44409:$array: new Uint8Array(
0x444d7:$array: new Uint8Array(
0x4450a:$array: new Uint8Array(
0x44718:$array: new Uint8Array(
0x450be:$array: new Uint8Array(
0x45e5d:$array: new Uint8Array(
0x45e75:$array: new Uint8Array(
0x4bc6a:$array: new Uint8Array(
0x7b9c:$jsxor: 2E 63 68 61 72 43 6F 64 65 41 74 28 6C 29 5E
```

Quick overview of the strings that are actually matching:
```
22 6D 73 53 61 76 65 => "msSave
2E637265 61746545 6C656D65 6E7428 => .createElement(
2E637265 6174654F 626A6563 7455524C 28 => .createObjectURL(
22 64 6F 77 6E 6C 6F 61 64 22 => "download"
2E 64 6F 77 6E 6C 6F 61 64 3D => .download=
22 63 6C 69 63 6B 22 => "click"
61 74 6F 62 28 => atob(
2E 63 68 61 72 43 6F 64 65 41 74 28 6C 29 5E => .charCodeAt(l)^
```

And the rule itself (for reference):
```yara
rule ELCEEF_HTML_Smuggling_A : T1027 FILE
{
	meta:
		description = "Generic detection for HTML smuggling (T1027.006)"
		author = "marcin@ulikowski.pl"
		id = "b711318f-81d2-5d0b-968f-04ae18fdea5b"
		date = "2021-05-13"
		modified = "2023-04-16"
		reference = "https://github.com/elceef/yara-rulz"
		source_url = "https://github.com/elceef/yara-rulz/blob/05834717d1464d5efce8ad9d688ff7b53886a0bb/rules/HTML_Smuggling.yara#L1-L31"
		license_url = "https://github.com/elceef/yara-rulz/blob/05834717d1464d5efce8ad9d688ff7b53886a0bb/LICENSE"
		logic_hash = "bc076e9f3d4c6d2aa5a3602436408e5b2ac3140ca9f7cc776c44835cba211951"
		score = 75
		quality = 75
		tags = "T1027, FILE"
		hash1 = "279d5ef8f80aba530aaac8afd049fa171704fc703d9cfe337b56639732e8ce11"

	strings:
		$mssave = { ( 2e | 22 | 27 ) 6d 73 53 61 76 65 }
		$element = { ( 2e | 22 | 27 ) 63 72 65 61 74 65 45 6c 65 6d 65 6e 74 ( 28 | 22 | 27 ) }
		$objecturl = { ( 2e | 22 | 27 ) 63 72 65 61 74 65 4f 62 6a 65 63 74 55 52 4c ( 28 | 22 | 27 ) }
		$download = { ( 2e | 22 | 27 ) 64 6f 77 6e 6c 6f 61 64 ( 3d | 22 | 27 ) }
		$click = { ( 2e | 22 | 27 ) 63 6c 69 63 6b ( 3d | 22 | 27 ) }
		$atob = { 61 74 6f 62 ( 28 | 22 | 27 ) }
		$blob = "new Blob("
		$array = "new Uint8Array("
		$ole2 = "0M8R4KGxGuEA"
		$pe32 = "TVqQAAMAAAAE"
		$iso = "AAAABQ0QwMDE"
		$udf = "AAAAQkVBMDEB"
		$zip = { 55 45 73 44 42 ( 41 | 42 | 43 | 44 ) ( 6f | 30 | 4d | 51 ) ( 41 | 44 ) ( 41 | 43 ) }
		$jsxor = { 2e 63 68 61 72 43 6f 64 65 41 74 28 [1-10] 29 ( 5e | 20 5e ) }

	condition:
		filesize <5MB and ($mssave or (#element==1 and #objecturl==1 and #download==1 and #click==1)) and $blob and $array and $atob and (#ole2+#pe32+#iso+#udf+#zip+#jsxor)==1
```