### PR TITLE
Address false positives for playwright and mongosh

### DIFF
--- a/rules/combo/backdoor/php.yara
+++ b/rules/combo/backdoor/php.yara
@@ -82,7 +82,9 @@ rule php_urlvar_recon_exec : critical {
     $f_phpinfo = "phpinfo("
     $x_GET = "_GET"
     $x_POST = "_POST"
+
     $not_php = "PHP_VERSION_ID"
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     any of ($p*) and any of ($e*) and any of ($f*) and any of ($x*) and none of ($not*)
 }
@@ -107,7 +109,9 @@ rule php_eval_gzinflate_base64_backdoor : critical {
     $f_html_special = "htmlspecialchars_decode"
     $f_gzinflate = "gzinflate("
     $f_base64_decode = "base64_decode"
+
     $not_php = "PHP_FLOAT_DIG" fullword
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     all of ($f*) and none of ($not*)
 }
@@ -122,8 +126,10 @@ rule php_obfuscated_with_hex_characters : high {
     $php = "<?php"
     $hex = /\\x\w{2}\w\\x/
     $hex_not_mix = /\\x\w{2}\w\\\d/
+
     $not_char_refs = "character_references"
     $not_auto = "AUTOMATICALLY GENERATED"
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     $php and (#hex > 5 or #hex_not_mix > 5) and none of ($not*)
 }
@@ -154,8 +160,10 @@ rule php_post_system : medium {
     $method_post = "_POST"
     $method_get = "_GET"
     $system = "system("
+
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
-    $php and any of ($method*) and $system
+    $php and any of ($method*) and $system and none of ($not*)
 }
 
 rule php_error_reporting_disable : high {

--- a/rules/combo/stealer/browser.yara
+++ b/rules/combo/stealer/browser.yara
@@ -52,10 +52,12 @@ rule multiple_browser_refs : critical {
     $name_opera = "Opera Software"
     $name_yandex = "YandexBrowser"
 
-	$not_google = "developed by Google"
-	$not_google_chrome_software = "The Google Chrome software"
-	$not_bugzilla = "https://bugzilla.mozilla.org"
-	$not_ff_js = "Firefox can even throw an error"
+    $not_google = "developed by Google"
+    $not_google_chrome_software = "The Google Chrome software"
+    $not_bugzilla = "https://bugzilla.mozilla.org"
+    $not_ff_js = "Firefox can even throw an error"
+    $not_generated_comment = "// This file is generated"
+    $not_generated_file = "/utils/generate_types/index.js"
   condition:
     2 of ($name*) and 3 of ($fs*) and none of ($not*)
 }
@@ -85,11 +87,12 @@ rule userdata_browser_archiver : medium {
     $b_Safari = "Safari"
     $b_Chrome = "Chrome"
 
-	$not_google = "developed by Google"
-	$not_google_chrome_software = "The Google Chrome software"
-	$not_bugzilla = "https://bugzilla.mozilla.org"
-	$not_ff_js = "Firefox can even throw an error"
-
+    $not_google = "developed by Google"
+    $not_google_chrome_software = "The Google Chrome software"
+    $not_bugzilla = "https://bugzilla.mozilla.org"
+    $not_ff_js = "Firefox can even throw an error"
+    $not_generated_comment = "// This file is generated"
+    $not_generated_file = "/utils/generate_types/index.js"
   condition:
     any of ($d*) and any of ($h*) and any of ($z*) and 2 of ($b*) and none of ($not*)
 }

--- a/rules/evasion/base64-php_functions.yara
+++ b/rules/evasion/base64-php_functions.yara
@@ -58,8 +58,10 @@ rule base64_php_functions : medium {
     $f_upload_dir = "wp_upload_dir" base64
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
+
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
-    $php and $base64_decode and any of ($f_*)
+    $php and $base64_decode and any of ($f_*) and none of ($not*)
 }
 
 rule base64_php_functions_multiple : critical {
@@ -121,6 +123,8 @@ rule base64_php_functions_multiple : critical {
     $f_upload_dir = "wp_upload_dir" base64
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
+
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
-    $php and $base64_decode and 2 of ($f_*)
+    $php and $base64_decode and 2 of ($f_*) and none of ($not*)
 }


### PR DESCRIPTION
This PR address false positives seen in recent `mongosh` and `playwright` update PRs.

The `mongosh` FPs were from a single `<?php` string match:
![CleanShot 2024-07-16 at 15 30 17@2x](https://github.com/user-attachments/assets/ddff1f03-717c-4c8c-bedb-8d9ceb6c26ab)

To avoid ignoring `<?php` matches in other files, I ignored the entire `mongosh`-specific `<?php ... ?>` string.

The `playwright` FPs were located in an autogenerated file which made ignoring them straightforward. We'll be able to add additional autogenerated file names to the `$not_` strings.