### PR TITLE
Address false positives for Chromium, KOTS, and Nuclei

### DIFF
--- a/rules/combo/stealer/browser.yara
+++ b/rules/combo/stealer/browser.yara
@@ -52,7 +52,9 @@ rule multiple_browser_refs : critical {
     $name_opera = "Opera Software"
     $name_yandex = "YandexBrowser"
 
-    $not_chromium = "When this is enabled, Chromium can use"
+    $not_chromium = "ChromiumBrowser"
+    $not_chromium_comment = "When this is enabled, Chromium can use"
+    $not_chromium_issues = "https://issues.chromium.org/"
     $not_google = "developed by Google"
     $not_google_chrome_software = "The Google Chrome software"
     $not_bugzilla = "https://bugzilla.mozilla.org"

--- a/rules/combo/stealer/browser.yara
+++ b/rules/combo/stealer/browser.yara
@@ -90,6 +90,7 @@ rule userdata_browser_archiver : medium {
 
     $not_chromium = "ChromiumBrowser"
     $not_chromium_comment = "When this is enabled, Chromium can use"
+    $not_chromium_issues = "https://issues.chromium.org/"
     $not_google = "developed by Google"
     $not_google_chrome_software = "The Google Chrome software"
     $not_bugzilla = "https://bugzilla.mozilla.org"

--- a/rules/combo/stealer/browser.yara
+++ b/rules/combo/stealer/browser.yara
@@ -52,6 +52,7 @@ rule multiple_browser_refs : critical {
     $name_opera = "Opera Software"
     $name_yandex = "YandexBrowser"
 
+    $not_chromium = "When this is enabled, Chromium can use"
     $not_google = "developed by Google"
     $not_google_chrome_software = "The Google Chrome software"
     $not_bugzilla = "https://bugzilla.mozilla.org"
@@ -87,6 +88,8 @@ rule userdata_browser_archiver : medium {
     $b_Safari = "Safari"
     $b_Chrome = "Chrome"
 
+    $not_chromium = "ChromiumBrowser"
+    $not_chromium_comment = "When this is enabled, Chromium can use"
     $not_google = "developed by Google"
     $not_google_chrome_software = "The Google Chrome software"
     $not_bugzilla = "https://bugzilla.mozilla.org"

--- a/rules/combo/stealer/wallet.yara
+++ b/rules/combo/stealer/wallet.yara
@@ -24,6 +24,13 @@ rule crypto_stealer : critical {
     $w_trezor = "Trezor"
     $w_exodus = "Exodus"
     $w_coinomi = "Coinomi"
+    $not_cats = /\"cats\": \[[^]]{0,64}/
+    $not_description = /\"description\": "([^"]{0,64})"/
+    $not_dom = /\"dom\": "([^"]{0,64})"/
+    $not_icon = /\"icon\": "([^"]{0,64})"/
+    $not_js  = /\"js\": \{[^}]{0,64}/
+    $not_scriptsrc = /\"scriptSrc\": "([^"]{0,64})"/
+    $not_website = /\"website\": "([^"]{0,64})"/
   condition:
-    $http and 2 of ($w*)
+    $http and 2 of ($w*) and none of ($not*)
 }

--- a/rules/evasion/base64-php_functions.yara
+++ b/rules/evasion/base64-php_functions.yara
@@ -59,8 +59,8 @@ rule base64_php_functions : medium {
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
-    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
     $not_comment = "// "
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     $php and $base64_decode and any of ($f_*) and none of ($not*)
 }
@@ -125,8 +125,8 @@ rule base64_php_functions_multiple : critical {
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
-    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
     $not_comment = "// "
+    $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     $php and $base64_decode and 2 of ($f_*) and none of ($not*)
 }

--- a/rules/evasion/base64-php_functions.yara
+++ b/rules/evasion/base64-php_functions.yara
@@ -59,7 +59,7 @@ rule base64_php_functions : medium {
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
-    $not_comment = "// "
+    $not_comment = "// processing instruction, e.g. <?php ?>"
     $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     $php and $base64_decode and any of ($f_*) and none of ($not*)
@@ -125,7 +125,7 @@ rule base64_php_functions_multiple : critical {
     $f_wp_nonce_field = "wp_nonce_field" base64
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
-    $not_comment = "// "
+    $not_comment = "// processing instruction, e.g. <?php ?>"
     $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
   condition:
     $php and $base64_decode and 2 of ($f_*) and none of ($not*)

--- a/rules/evasion/base64-php_functions.yara
+++ b/rules/evasion/base64-php_functions.yara
@@ -60,6 +60,7 @@ rule base64_php_functions : medium {
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
     $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
+    $not_comment = "// "
   condition:
     $php and $base64_decode and any of ($f_*) and none of ($not*)
 }
@@ -125,6 +126,7 @@ rule base64_php_functions_multiple : critical {
     $f_wp_verify_nonce = "wp_verify_nonce" base64
 
     $not_mongosh_php = { 3C 3F 70 68 70 00 00 00 01 0C 51 61 03 00 00 00 02 00 00 00 3F 3E }
+    $not_comment = "// "
   condition:
     $php and $base64_decode and 2 of ($f_*) and none of ($not*)
 }


### PR DESCRIPTION
This PR addresses critical false positives seen here:
- https://github.com/wolfi-dev/os/pull/24105
- https://github.com/wolfi-dev/os/pull/24107
- https://github.com/wolfi-dev/os/pull/24139

Notes:
- The Chromium false positives were due to our only ignoring `Chrome` strings
- The KOTS false positives were due to PHP tags located in a comment
- The Nuclei false positives were due to strings matching Wapalyzer technology JSON content
  - Specifically, content from this file: https://github.com/Lissy93/wapalyzer/blob/main/src/technologies/c.json


I used slightly more specific strings when ignoring the Nuclei false positives since they were originating from JSON content and I wanted to match the exact fields rather than doing something like `$not_description = "\"description\": \""`.
