### PR TITLE
Address py3-setuptools false positives

### DIFF
--- a/rules/combo/backdoor/py_setuptools.yara
+++ b/rules/combo/backdoor/py_setuptools.yara
@@ -22,8 +22,8 @@ rule setuptools_cmd_exec : suspicious {
     $f_os_system = /os.system\([\"\'\w\ \-\)\/]{0,64}/
     $f_os_popen = /os.spopen\([\"\'\w\ \-\)\/]{0,64}/
     $f_subprocess = /subprocess.\w{0,32}\([\"\'\/\w\ \-\)]{0,64}/
+    $not_comment = "Editable install to a prefix should be discoverable."
     $not_egg_info_requires = "os.path.join(egg_info_dir, 'requires.txt')"
-    $not_sample = "# now run 'sample' with the prefix on the PYTHONPATH"
   condition:
     pythonSetup and any of ($f*) and none of ($not*)
 }

--- a/rules/combo/backdoor/py_setuptools.yara
+++ b/rules/combo/backdoor/py_setuptools.yara
@@ -34,7 +34,7 @@ rule setuptools_eval : critical {
   strings:
     $f_sys_val = /eval\([\"\'\w\ \-\)\/]{0,64}/ fullword
     $f_subprocess_val = /exec\([\"\'\/\w\ \-\)]{0,64}/ fullword
-    $not_comment = "This test focus in getting a particular implementation detail right."
+    $not_comment = "Editable install to a prefix should be discoverable."
     $not_test_egg_class = "class TestEggInfo"
   condition:
     pythonSetup and any of ($f*) and none of ($not*)

--- a/rules/combo/backdoor/py_setuptools.yara
+++ b/rules/combo/backdoor/py_setuptools.yara
@@ -19,11 +19,13 @@ rule setuptools_cmd_exec : suspicious {
   meta:
     description = "Python library installer that executes external commands"
   strings:
-    $os_system = /os.system\([\"\'\w\ \-\)\/]{0,64}/
-    $os_popen = /os.spopen\([\"\'\w\ \-\)\/]{0,64}/
-    $subprocess = /subprocess.\w{0,32}\([\"\'\/\w\ \-\)]{0,64}/
+    $f_os_system = /os.system\([\"\'\w\ \-\)\/]{0,64}/
+    $f_os_popen = /os.spopen\([\"\'\w\ \-\)\/]{0,64}/
+    $f_subprocess = /subprocess.\w{0,32}\([\"\'\/\w\ \-\)]{0,64}/
+    $not_egg_info_requires = "os.path.join(egg_info_dir, 'requires.txt')"
+    $not_sample = "# now run 'sample' with the prefix on the PYTHONPATH"
   condition:
-    pythonSetup and any of them
+    pythonSetup and any of ($f*) and none of ($not*)
 }
 
 rule setuptools_eval : critical {
@@ -32,8 +34,10 @@ rule setuptools_eval : critical {
   strings:
     $f_sys_val = /eval\([\"\'\w\ \-\)\/]{0,64}/ fullword
     $f_subprocess_val = /exec\([\"\'\/\w\ \-\)]{0,64}/ fullword
+    $not_comment = "This test focus in getting a particular implementation detail right."
+    $not_test_egg_class = "class TestEggInfo"
   condition:
-    pythonSetup and any of ($f*)
+    pythonSetup and any of ($f*) and none of ($not*)
 }
 
 rule setuptools_b64decode : suspicious {
@@ -61,8 +65,9 @@ rule setuptools_os_path_exists : notable {
     description = "Python library installer that checks for file existence"
   strings:
     $ref = /[\w\.]{0,8}path.exists\([\"\'\w\ \-\)\/]{0,32}/
+    $not_egg_info_requires = "os.path.join(egg_info_dir, 'requires.txt')"
   condition:
-    pythonSetup and $ref
+    pythonSetup and $ref and none of ($not*)
 }
 
 rule setuptools_excessive_bitwise_math : critical {


### PR DESCRIPTION
This PR addresses the two false positives seen here: https://github.com/wolfi-dev/os/pull/24222

Since these are Python tests, there's not a lot to key off of for exceptions. I chose a combination of comments and semi-unique strings.