### PR TITLE
Bump bincapz version to 0.16.0 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.15.1"
+	ID string = "v0.16.0"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
This PR bumps the version string to `0.16.0` ahead of cutting a new release.