### PR TITLE
More /dev/tcp rule tweaks for GitLab healthcheck script

### DIFF
--- a/rules/shell/bash_dev_tcp.yara
+++ b/rules/shell/bash_dev_tcp.yara
@@ -8,8 +8,11 @@ rule bash_dev_tcp : high exfil {
   strings:
     $ref = "/dev/tcp"
     $posixly_correct = "POSIXLY_CORRECT"
+    $not_comment = "# Check that both our processes are running on their tcp port"
+    $not_get = /GET \/ HTTP\/1.1\n{1,2} >/
+    $not_localhost_8080 = "/dev/tcp/127.0.0.1/8080"
   condition:
-    $ref and not $posixly_correct
+    $ref and not $posixly_correct and none of ($not*)
 }
 
 
@@ -19,8 +22,8 @@ rule bash_dev_tcp_hardcoded_ip : critical {
   strings:
     $dev_tcp = /\/dev\/tcp\/[\w\.]{8,16}\/\d{1,6}/
     $not_comment = "# Check that both our processes are running on their tcp port"
-    $not_get = "GET / HTTP/1.1 >"
+    $not_get = /GET \/ HTTP\/1.1\n{1,2} >/
     $not_localhost_8080 = "/dev/tcp/127.0.0.1/8080"
   condition:
-	  $dev_tcp and none of ($not_*)
+	  $dev_tcp and none of ($not*)
 }

--- a/samples/Linux/clean/healthcheck.simple
+++ b/samples/Linux/clean/healthcheck.simple
@@ -1,5 +1,4 @@
 # Linux/clean/healthcheck
 net/http/request
 ref/path/dev
-shell/bash_dev_tcp
 shell/exec


### PR DESCRIPTION
This PR addresses a false positive seen here: https://github.com/chainguard-dev/enterprise-packages/pull/5949

We resolved this for the `bash_dev_tcp_hardcoded_ip` rule but not the `bash_dev_tcp` rule.

Results before this change:
```
$ yara -r rules/shell/bash_dev_tcp.yara /tmp/bincapz/gitlab-cng/x86_64/scripts/healthcheck -s
bash_dev_tcp /tmp/bincapz/gitlab-cng/x86_64/scripts/healthcheck
0x71:$ref: /dev/tcp
```

After:
```
$ yara -r rules/shell/bash_dev_tcp.yara /tmp/bincapz/gitlab-cng/x86_64/scripts/healthcheck -c
0
```