### PR TITLE
Bump bincapz version to 0.16.1 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.16.0"
+	ID string = "v0.16.1"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
This PR bumps the bincapz version to `0.16.1` ahead of cutting the new release.