### PR TITLE
Bump bincapz version to 0.16.2 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.16.1"
+	ID string = "v0.16.2"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
With #378 containing so many false positive fixes, I want to get another patch release out so that our bases are covered for any upcoming package updates.

This will probably be the last "quick" release for a while as we work toward a GA/1.0.0 release of bincapz (or whatever we rename it to).