### PR TITLE
Address mlflow PyPI index JSON false positive

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -27,6 +27,7 @@ var badRules = map[string]bool{
 	"ELCEEF_HTML_Smuggling_A":                             true,
 	"DELIVRTO_SUSP_HTML_WASM_Smuggling":                   true,
 	"SIGNATURE_BASE_FVEY_Shadowbroker_Auct_Dez16_Strings": true,
+	"ELASTIC_Macos_Creddump_Keychainaccess_535C1511":      true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,


### PR DESCRIPTION
This PR addresses the false positive seen in this `mlflow` PR: https://github.com/wolfi-dev/os/pull/25095

`mlflow` downloads the entire PyPI package index and stores the package names (556,506 package names in total) in a JSON file which causes a lot of false-positive string matches (though only one critical which was a third-party rule).