### PR TITLE
Address false positives with argo-workflows-ui

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -30,6 +30,7 @@ var badRules = map[string]bool{
 	"SIGNATURE_BASE_FVEY_Shadowbroker_Auct_Dez16_Strings": true,
 	"ELASTIC_Macos_Creddump_Keychainaccess_535C1511":      true,
 	"SIGNATURE_BASE_Reconcommands_In_File":                true,
+	"SIGNATURE_BASE_Apt_CN_Tetrisplugins_JS":              true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,


### PR DESCRIPTION
This PR addresses the false positives seen here:
- https://github.com/wolfi-dev/os/pull/25248
- https://github.com/wolfi-dev/os/pull/25154

Again, this was due to a third-party rule.

The package in question: https://www.npmjs.com/package/minim

This is how `minim.js` is created:
https://github.com/refractproject/minim/blob/2a7996d3e66da6a1cc1601cbdbcb4290ebf664be/package.json#L10