### PR TITLE
Bump bincapz version to 0.17.0 ahead of release

### DIFF
--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -6,7 +6,7 @@ import (
 )
 
 const (
-	ID string = "v0.16.2"
+	ID string = "v0.17.0"
 )
 
 // Check if the build info contains a version.


### PR DESCRIPTION
This PR bumps the bincapz version string to `0.17.0` before cutting the new release.