### PR TITLE
Scan file descriptors rather than files per go-yara docs

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -82,7 +82,13 @@ func scanSinglePath(ctx context.Context, c bincapz.Config, yrs *yara.Rules, path
 	}
 
 	logger.Debug("calling YARA ScanFile")
-	if err := yrs.ScanFile(path, 0, 0, &mrs); err != nil {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	fd := f.Fd()
+	if err := yrs.ScanFileDescriptor(fd, 0, 0, &mrs); err != nil {
 		logger.Info("skipping", slog.Any("error", err))
 		return &bincapz.FileReport{Path: path, Error: fmt.Sprintf("scanfile: %v", err)}, nil
 	}


### PR DESCRIPTION
This is a quick PR to swap over from scanning files to scanning file descriptors.

`go-yara`'s documentation mentions that this is the better route in a comment above `ScanFile`:
```go
// ScanFile scans a file using the ruleset. For every
// event emitted by libyara, the corresponding method on the
// ScanCallback object is called.
//
// Note that the filename is passed as-is to the YARA library and may
// not be processed in a sensible way. It is recommended to avoid this
// function and to obtain an os.File handle f using os.Open() and use
// ScanFileDescriptor(f.Fd(), …) instead.
```

In my testing, this shaved off several seconds of overhead.