### PR TITLE
Add octo-sts identity to help with release automation

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -1,0 +1,8 @@
+issuer: https://token.actions.githubusercontent.com
+subject: repo:chainguard-dev/bincapz:ref:refs/heads/main
+claim_pattern:
+  job_workflow_ref: chainguard-dev/bincapz/.github/workflows/(version|release).yaml@.*
+
+permissions:
+  contents: write
+  pull-requests: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,6 +20,12 @@ jobs:
         egress-policy: audit
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
     - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
+    - name: Set up Octo-STS
+      uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo-sts
+      with:
+        scope: chainguard-dev/bincapz
+        identity: release
     - name: Get Version
       id: get-version
       run: |
@@ -31,7 +37,7 @@ jobs:
         echo "VERSION=$VERSION" >> "$GITHUB_OUTPUT"
     - name: Create Release
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       if: ${{ steps.get-version.outputs.VERSION != '' }}
       run: |
         VERSION=${{ steps.get-version.outputs.VERSION }}

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -26,6 +26,12 @@ jobs:
         egress-policy: audit 
     - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332
     - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
+    - name: Set up Octo-STS
+      uses: octo-sts/action@6177b4481c00308b3839969c3eca88c96a91775f # v1.0.0
+      id: octo-sts
+      with:
+        scope: chainguard-dev/bincapz
+        identity: release
     - name: Update Version
       id: update
       run: |
@@ -77,7 +83,7 @@ jobs:
         echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
     - name: Create Pull Request
       env:
-        GH_TOKEN: ${{ github.token }}
+        GH_TOKEN: ${{ steps.octo-sts.outputs.token }}
       run: |
         VERSION=${{ steps.update.outputs.VERSION }}
         gh pr create -t "Update bincapz to $VERSION" -b "PR to update the version in ${{ env.VERSION_FILE }} to $VERSION" -B main


### PR DESCRIPTION
Workflows in PRs created by the default `GH_TOKEN` won't run which we need for our version bump PRs. We should use octo-sts to help us out here.

Relevant GitHub Discussion: https://github.com/orgs/community/discussions/25602