### PR TITLE
Fix trust policy

### DIFF
--- a/.github/chainguard/release.sts.yaml
+++ b/.github/chainguard/release.sts.yaml
@@ -5,4 +5,4 @@ claim_pattern:
 
 permissions:
   contents: write
-  pull-requests: write
+  pull_requests: write


### PR DESCRIPTION
One of these days I'll implement an octo-sts trust policy correctly on the first try.

`pull-request` is invalid; `pull_request` is the correct permission.