### PR TITLE
Remove GitHub user configuration from Workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,6 +46,4 @@ jobs:
           exit 1
         fi
         git config --global tag.gpgsign true
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         gh release create "$VERSION" --title "$VERSION" --notes "Release $VERSION" --draft

--- a/.github/workflows/version.yaml
+++ b/.github/workflows/version.yaml
@@ -71,9 +71,7 @@ jobs:
         echo "New bincapz version: $VERSION"
         
         sed -i "s/ID string = \"v[0-9]*\.[0-9]*\.[0-9]*\"/ID string = \"${VERSION}\"/" ${{ env.VERSION_FILE }}
-        
-        git config user.name "github-actions[bot]"
-        git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
         BRANCH="bincapz-version-bump-$VERSION"
         git checkout -b $BRANCH
         git add ${{ env.VERSION_FILE }}


### PR DESCRIPTION
Now that we're using octo-sts, we should be able to rely on its `user.name` and `user.email` configuration instead of overriding it with default `github-actions[bot]` configurations.