### PR TITLE
Fix sort bug

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -275,10 +275,7 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 		var pathKeys []string
 		results.Range(func(key, value interface{}) bool {
 			if k, ok := key.(string); ok {
-				func(key string) {
-					pathKeys = append(pathKeys, key)
-					slices.Sort(pathKeys)
-				}(k)
+				pathKeys = append(pathKeys, k)
 				value, ok := value.(*bincapz.FileReport)
 				if !ok {
 					return false
@@ -287,6 +284,7 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 			}
 			return true
 		})
+		slices.Sort(pathKeys)
 
 		// OCI images hadle their match his/miss logic per scanPath
 		if c.OCI {


### PR DESCRIPTION
I noticed that our concurrent scan of the Keycloak package (~185,000) files was taking about 2-3 minutes longer with concurrency than it had originally without any concurrency.

I didn't catch this in the concurrency PR, but we're sorting the `pathKeys` slice each time `results.Range` iterates over the `results` map. Over hundreds of thousands files, this really adds up and explains why we didn't catch the bug in our current samples which do not contain many files.

This PR sorts the `pathKeys` slice after we're done iterating and also removes the unnecessary anonymous function inside of the `Range` function.