### PR TITLE
Keep frp rule turned on

### DIFF
--- a/pkg/compile/compile.go
+++ b/pkg/compile/compile.go
@@ -31,7 +31,6 @@ var badRules = map[string]bool{
 	"ELASTIC_Macos_Creddump_Keychainaccess_535C1511":      true,
 	"SIGNATURE_BASE_Reconcommands_In_File":                true,
 	"SIGNATURE_BASE_Apt_CN_Tetrisplugins_JS":              true,
-	"ELASTIC_Linux_Proxy_Frp_4213778F":                    true,
 	// ThreatHunting Keywords (some duplicates)
 	"Adobe_XMP_Identifier":                       true,
 	"Antivirus_Signature_signature_keyword":      true,


### PR DESCRIPTION
After some back and forth, it makes sense to leave this rule turned on (since it's in a similar vein to `exploitdb`).

When updating this package, we'll filter out the critical finding on the Check/linting side rather than turning it off globally.