### PR TITLE
Make all map operations concurrency-safe; fix nested archive extraction

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -165,7 +165,7 @@ func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, 
 
 // recursiveScan recursively YARA scans the configured paths - handling archives and OCI images.
 //
-//nolint:gocognit // ignoring complexity of 102 > 98
+
 func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, error) {
 	logger := clog.FromContext(ctx)
 	logger.Debug("recursive scan", slog.Any("config", c))
@@ -277,9 +277,8 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 			g.Go(func() error {
 				if isSupportedArchive(path) {
 					return handleArchive(path)
-				} else {
-					return handleFile(path)
 				}
+				return handleFile(path)
 			})
 		}
 
@@ -288,7 +287,7 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 		}
 
 		var pathKeys []string
-		scanPathFindings.Range(func(key, value interface{}) bool {
+		scanPathFindings.Range(func(key, _ interface{}) bool {
 			if k, ok := key.(string); ok {
 				pathKeys = append(pathKeys, k)
 			}


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/423

We were still using `map[any]any` types for operations happening within Goroutines. This was causing non-deterministic numbers of paths to be scanned (sometimes correct, sometimes way too many, sometimes too few). The main culprit was `extractedFiles := make(map[string]bool)` which was used when handling nested archive extraction, so really, this problem was limited to scanning archives or nested archives.

This PR replaces all remaining `map[any]any` types used within `scan.go` with `sync.Map` types.

With the original testing, I would see 1/4-1/5 of the attempts produce an incorrect number of paths and now the number of scan paths is always correct (as checked against an older version of bincapz).

To validate this change, I'm running an endless loop and printing the number of files:
```
$ while true; go run . --min-file-risk any --format=json ~/Downloads/archive.zip | jq -r '.Files | length'; end
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
9
```

Earlier, there were several instances of `4` instead of `9` which was the giveaway that something wasn't right.