### PR TITLE
Add .xz archive support

### DIFF
--- a/.github/workflows/go-tests.yaml
+++ b/.github/workflows/go-tests.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-      
+
       - name: Checkout code
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
@@ -47,9 +47,9 @@ jobs:
           sudo add-apt-repository -n -y "deb http://security.ubuntu.com/ubuntu mantic-security main restricted universe multiverse"
 
           sudo apt update && sudo apt install libyara-dev -y
-        
+
       - name: Prepare samples
-        run : |
+        run: |
           cp -a ${{ github.workspace }}/test_data/. ${{ github.workspace }}/samples/
           for file in caddy.xz chezmoi.xz minio_x86_64.xz mongosh.xz neuvector_agent_aarch64.xz opa.xz ; do \
             tar -xJvf ${{ github.workspace }}/samples/linux/clean/${file} -C ${{ github.workspace }}/samples/linux/clean; \

--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -48,7 +48,7 @@ func extractTar(ctx context.Context, d string, f string) error {
 		}
 		defer gzStream.Close()
 		tr = tar.NewReader(gzStream)
-	case strings.Contains(filename, ".tar.xz"):
+	case strings.Contains(filename, ".xz"):
 		_, err := tf.Seek(0, io.SeekStart) // Seek to start for xz reading
 		if err != nil {
 			return fmt.Errorf("failed to seek to start: %w", err)
@@ -347,7 +347,7 @@ func extractionMethod(ext string) func(context.Context, string, string) error {
 		return extractZip
 	case ".gz":
 		return extractGzip
-	case ".apk", ".gem", ".tar", ".tar.gz", ".tgz", ".tar.xz":
+	case ".apk", ".gem", ".tar", ".tar.gz", ".tgz", ".tar.xz", ".xz":
 		return extractTar
 	default:
 		return nil

--- a/pkg/action/programkind.go
+++ b/pkg/action/programkind.go
@@ -27,6 +27,7 @@ var archiveMap = map[string]bool{
 	".tar.xz": true,
 	".tar":    true,
 	".tgz":    true,
+	".xz":     true,
 	".zip":    true,
 }
 


### PR DESCRIPTION
We've had support for `.tar.xz` files but not `.xz` files. This PR tweaks our `.tar.xz` checks to support both.

This will allow us to scan our archived sample binaries without needing to extract them as part of the repository cloning. To do so, I'll need to make the archive names match the `.simple` file names so that's for a later PR.