### PR TITLE
Add nil checks when iterating over sync.Maps

### DIFF
--- a/pkg/action/archive.go
+++ b/pkg/action/archive.go
@@ -293,6 +293,9 @@ func extractArchiveToTempDir(ctx context.Context, path string) (string, error) {
 	}
 
 	extractedFiles.Range(func(key, _ any) bool {
+		if key == nil {
+			return true
+		}
 		//nolint: nestif // ignoring complexity of 11
 		if file, ok := key.(string); ok {
 			ext := getExt(file)

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -129,6 +129,9 @@ func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, 
 	var bMap sync.Map
 	count := 0
 	frs.Range(func(_, value any) bool {
+		if value == nil {
+			return true
+		}
 		if fr, ok := value.(*bincapz.FileReport); ok {
 			for _, b := range fr.Behaviors {
 				count++
@@ -140,6 +143,9 @@ func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, 
 
 	bList := []string{}
 	bMap.Range(func(key, _ any) bool {
+		if key == nil {
+			return true
+		}
 		if k, ok := key.(string); ok {
 			bList = append(bList, k)
 		}
@@ -165,7 +171,7 @@ func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, 
 
 // recursiveScan recursively YARA scans the configured paths - handling archives and OCI images.
 //
-
+//nolint:gocognit // ignoring complexity of 101 > 98
 func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, error) {
 	logger := clog.FromContext(ctx)
 	logger.Debug("recursive scan", slog.Any("config", c))
@@ -234,6 +240,9 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 			}
 
 			frs.Range(func(key, value any) bool {
+				if key == nil || value == nil {
+					return true
+				}
 				if k, ok := key.(string); ok {
 					if fr, ok := value.(*bincapz.FileReport); ok {
 						scanPathFindings.Store(k, fr)
@@ -288,6 +297,9 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 
 		var pathKeys []string
 		scanPathFindings.Range(func(key, _ interface{}) bool {
+			if key == nil {
+				return true
+			}
 			if k, ok := key.(string); ok {
 				pathKeys = append(pathKeys, k)
 			}


### PR DESCRIPTION
Closes: https://github.com/chainguard-dev/bincapz/issues/434

I noticed a handful of panics when looking at the bincapz Job logs. This PR checks whether the key, value, or both are nil before we try to access their values across various `sync.Map`s.