### PR TITLE
Add shorter output format for 'scan' mode

### DIFF
--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -15,6 +15,8 @@ func New(kind string, w io.Writer) (bincapz.Renderer, error) {
 	switch kind {
 	case "", "auto", "terminal":
 		return NewTerminal(w), nil
+	case "terminal_brief":
+		return NewTerminalBrief(w), nil
 	case "markdown":
 		return NewMarkdown(w), nil
 	case "yaml":

--- a/pkg/render/terminal_brief.go
+++ b/pkg/render/terminal_brief.go
@@ -1,0 +1,69 @@
+// Copyright 2024 Chainguard, Inc.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Terminal Brief renderer
+//
+// Example:
+//
+// [CRITICAL] /bin/ls: frobber (whatever), xavier (whatever)
+// [HIGH    ] /bin/zxa:
+// [MED     ] /bin/ar:
+
+package render
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/chainguard-dev/bincapz/pkg/bincapz"
+	"github.com/fatih/color"
+)
+
+type TerminalBrief struct {
+	w io.Writer
+}
+
+func NewTerminalBrief(w io.Writer) TerminalBrief {
+	return TerminalBrief{w: w}
+}
+
+func briefRiskColor(level string) string {
+	switch level {
+	case "LOW":
+		return color.HiGreenString("LOW ")
+	case "MEDIUM", "MED":
+		return color.HiYellowString("MED ")
+	case "HIGH":
+		return color.HiRedString("HIGH")
+	case "CRITICAL", "CRIT":
+		return color.HiMagentaString("CRIT")
+	default:
+		return color.WhiteString(level)
+	}
+}
+
+func (r TerminalBrief) File(_ context.Context, fr *bincapz.FileReport) error {
+	if len(fr.Behaviors) == 0 {
+		return nil
+	}
+
+	reasons := []string{}
+	for _, b := range fr.Behaviors {
+		reasons = append(reasons, fmt.Sprintf("%s %s%s%s", color.HiYellowString(b.ID), color.HiBlackString("("), b.Description, color.HiBlackString(")")))
+	}
+
+	fmt.Fprintf(r.w, "%s%s%s %s: %s", color.HiBlackString("["), briefRiskColor(fr.RiskLevel), color.HiBlackString("]"), color.HiGreenString(fr.Path),
+		strings.Join(reasons, color.HiBlackString(", ")))
+	return nil
+}
+
+func (r TerminalBrief) Full(_ context.Context, rep *bincapz.Report) error {
+	// Non-diff files are handled on the fly by File()
+	if rep.Diff == nil {
+		return nil
+	}
+
+	return fmt.Errorf("diffs are unsupported by the TerminalBrief renderer")
+}


### PR DESCRIPTION
Example output:

```
[CRIT] ../bincapz-samples/linux/2021.FontOnLake/45E9.elf: 3P/elastic/rootkit/fontonlake (Detects Linux Rootkit Fontonlake (Linux.Rootkit.Fontonlake)), 3P/signature_base/susp/elf (Detects a suspicious ELF binary with UPX compression)

tip: For detailed analysis, run: bincapz analyze <path>
```


<img width="974" alt="Screenshot 2024-09-15 at 8 32 03 PM" src="https://github.com/user-attachments/assets/421127f6-0ca5-4502-9fa4-44048b728b03">
