### PR TITLE
Don't return after encountering a report with lower than minimum risk

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -328,7 +328,7 @@ func recursiveScan(ctx context.Context, c bincapz.Config) (*bincapz.Report, erro
 				r.Files.Set(k, fr)
 				if c.Renderer != nil && r.Diff == nil {
 					if fr.RiskScore < c.MinFileRisk {
-						return nil, nil
+						continue
 					}
 					if err := c.Renderer.File(ctx, fr); err != nil {
 						return nil, fmt.Errorf("render: %w", err)


### PR DESCRIPTION
Fixes: https://github.com/chainguard-dev/bincapz/issues/449

I believe this is all that's needed to address the empty results bug in the aforementioned Issue. With the current behavior, we'd return early rather than continuing to iterate through the file reports as soon as a file report with a lower risk was encountered.

@tstromberg -- feel free to validate this with the samples you noted in #449.

Prior to the concurrency changes, `processFile` used to return `nil, nil` for this comparison and the value of `processFile` was then ignored via a `continue` if it was `nil`: https://github.com/chainguard-dev/bincapz/blob/cb97c603c01a176b893b9616ee62d7d938bad759/pkg/action/scan.go#L229-L235