### PR TITLE
Check if frs Map is nil before ranging over it

### DIFF
--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -126,36 +126,40 @@ func isSupportedArchive(path string) bool {
 
 // errIfMatch generates the right error if a match is encountered.
 func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, errIfMiss bool) error {
-	var bMap sync.Map
-	count := 0
-	frs.Range(func(_, value any) bool {
-		if value == nil {
-			return true
-		}
-		if fr, ok := value.(*bincapz.FileReport); ok {
-			for _, b := range fr.Behaviors {
-				count++
-				bMap.Store(b.ID, true)
+	var (
+		bList  []string
+		bMap   sync.Map
+		count  int
+		suffix string = ""
+	)
+	if frs != nil {
+		frs.Range(func(_, value any) bool {
+			if value == nil {
+				return true
 			}
-		}
-		return true
-	})
-
-	bList := []string{}
-	bMap.Range(func(key, _ any) bool {
-		if key == nil {
+			if fr, ok := value.(*bincapz.FileReport); ok {
+				for _, b := range fr.Behaviors {
+					count++
+					bMap.Store(b.ID, true)
+				}
+			}
 			return true
-		}
-		if k, ok := key.(string); ok {
-			bList = append(bList, k)
-		}
-		return true
-	})
-	sort.Strings(bList)
+		})
 
-	suffix := ""
-	if len(bList) > 0 {
-		suffix = fmt.Sprintf(": %s", strings.Join(bList, " "))
+		bMap.Range(func(key, _ any) bool {
+			if key == nil {
+				return true
+			}
+			if k, ok := key.(string); ok {
+				bList = append(bList, k)
+			}
+			return true
+		})
+		sort.Strings(bList)
+
+		if len(bList) > 0 {
+			suffix = fmt.Sprintf(": %s", strings.Join(bList, " "))
+		}
 	}
 
 	// Behavioral note: this logic is per-archive or per-file, depending on context

--- a/pkg/action/scan.go
+++ b/pkg/action/scan.go
@@ -130,7 +130,7 @@ func errIfHitOrMiss(frs *sync.Map, kind string, scanPath string, errIfHit bool, 
 		bList  []string
 		bMap   sync.Map
 		count  int
-		suffix string = ""
+		suffix string
 	)
 	if frs != nil {
 		frs.Range(func(_, value any) bool {


### PR DESCRIPTION
Closes https://github.com/chainguard-dev/bincapz/issues/458

The `.jar` file in the aforementioned issue failed to extract:
```
time=2024-09-15T21:08:02.374-04:00 level=ERROR source=/Users/t/src/bincapz/pkg/action/scan.go:233 msg="unable to process ../malware/Downloads/909a19d0de5476e249c133f73c4afa288982d05dcf4ca597fa8357d93f435c47.jar: extract to temp: failed to extract ../malware/Downloads/909a19d0de5476e249c133f73c4afa288982d05dcf4ca597fa8357d93f435c47.jar: failed to open zip file ../malware/Downloads/909a19d0de5476e249c133f73c4afa288982d05dcf4ca597fa8357d93f435c47.jar: zip: not a valid zip file"
```

Which means the `frs` Map was not populated (i.e., was still `nil`) before we tried to use the `Range()` method (and we're passing in a pointer to the Map via `frs *sync.Map`):
```go
frs.Range(func(_, value any) bool {
    ...
}
```

This PR should handle cases like this more resiliently.